### PR TITLE
Part1

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ Svelte is an MIT-licensed open source project with its ongoing development made 
 
 Funds donated via Open Collective will be used for compensating expenses related to Svelte's development such as hosting costs. If sufficient donations are received, funds may also be used to support Svelte's development more directly.
 
+## i18n
+
+This is the french version of the Svelte website.
+
+If you are willing to fork this project and translate it into your own language, you will need to add the `PUBLIC_SVELTE_SITE_URL`, `PUBLIC_KIT_SITE_URL`, `PUBLIC_LEARN_SITE_URL` and `PUBLIC_GITHUB_ORG` to your environment variables to point to your local Svelte sites and Github organization.
+
 ## License
 
 [MIT](https://github.com/sveltejs/kit/blob/master/LICENSE)

--- a/documentation/docs/10-getting-started/10-introduction.md
+++ b/documentation/docs/10-getting-started/10-introduction.md
@@ -4,19 +4,19 @@ title: Introduction
 
 ## Avant de commencer
 
-> Si vous débutez avec Svelte ou SvelteKit, nous vous recommandons de jeter un œil au [tutoriel interactif](LEARN_SITE_URL).
+> Si vous débutez avec Svelte ou SvelteKit, nous vous recommandons de jeter un œil au [tutoriel interactif](PUBLIC_LEARN_SITE_URL).
 >
-> Si vous êtes bloqué•e, n'hésitez pas à demander de l'aide sur le forum du [Discord francophone](SVELTE_SITE_URL/chat), ou bien du [Discord officiel](https://svelte.dev/chat).
+> Si vous êtes bloqué•e, n'hésitez pas à demander de l'aide sur le forum du [Discord francophone](PUBLIC_SVELTE_SITE_URL/chat), ou bien du [Discord officiel](https://svelte.dev/chat).
 
 ## C'est quoi SvelteKit ?
 
-SvelteKit est un <span class="vo">[framework](SVELTE_SITE_URL/docs/web#framework)</span> permettant de développer des applications web robustes et performantes avec [Svelte](SVELTE_SITE_URL). Si vous êtes habitué•e à React, SvelteKit est comparable à Next. Si vous êtes habitué•e à Vue, SvelteKit est comparable à Nuxt.
+SvelteKit est un <span class="vo">[framework](PUBLIC_SVELTE_SITE_URL/docs/web#framework)</span> permettant de développer des applications web robustes et performantes avec [Svelte](PUBLIC_SVELTE_SITE_URL). Si vous êtes habitué•e à React, SvelteKit est comparable à Next. Si vous êtes habitué•e à Vue, SvelteKit est comparable à Nuxt.
 
 Pour en apprendre plus sur les types d'application que vous pouvez construire avec SvelteKit, rendez-vous sur la [FàQ](/docs/faq#what-can-i-make-with-sveltekit)
 
 ## C'est quoi Svelte ?
 
-Pour faire court, Svelte est un moyen d'écrire des composants d'interface visuelle — comme une barre de navigation, une section de commentaires, ou un formulaire de contact — que les utilisateurs et utilisatrices voient et utilisent dans leurs navigateurs. Le compilateur Svelte convertit vos composants en du code JavaScript qui peut être exécuté pour afficher le HTML des pages, ainsi qu'en CSS qui applique le style des pages. Vous n'avez pas besoin de connaître Svelte pour comprendre le reste de ce guide, mais cela peut définitivement aider. Si vous souhaitez en savoir plus, n'hésitez pas à aller faire le [tutoriel dédié à Svelte](SVELTE_SITE_URL/tutorial)
+Pour faire court, Svelte est un moyen d'écrire des composants d'interface visuelle — comme une barre de navigation, une section de commentaires, ou un formulaire de contact — que les utilisateurs et utilisatrices voient et utilisent dans leurs navigateurs. Le compilateur Svelte convertit vos composants en du code JavaScript qui peut être exécuté pour afficher le HTML des pages, ainsi qu'en CSS qui applique le style des pages. Vous n'avez pas besoin de connaître Svelte pour comprendre le reste de ce guide, mais cela peut définitivement aider. Si vous souhaitez en savoir plus, n'hésitez pas à aller faire le [tutoriel dédié à Svelte](PUBLIC_SVELTE_SITE_URL/tutorial)
 
 ## SvelteKit vs Svelte
 

--- a/documentation/docs/10-getting-started/10-introduction.md
+++ b/documentation/docs/10-getting-started/10-introduction.md
@@ -2,26 +2,26 @@
 title: Introduction
 ---
 
-## Before we begin
+## Avant de commencer
 
-> If you're new to Svelte or SvelteKit we recommend checking out the [interactive tutorial](LEARN_SITE_URL).
+> Si vous débutez avec Svelte ou SvelteKit, nous vous recommandons de jeter un œil au [tutoriel interactif](LEARN_SITE_URL).
 >
-> If you get stuck, reach out for help in the [Discord chatroom](https://svelte.dev/chat).
+> Si vous êtes bloqué•e, n'hésitez pas à demander de l'aide sur le forum du [Discord francophone](SVELTE_SITE_URL/chat), ou bien du [Discord officiel](https://svelte.dev/chat).
 
-## What is SvelteKit?
+## C'est quoi SvelteKit ?
 
-SvelteKit is a framework for rapidly developing robust, performant web applications using [Svelte](https://svelte.dev/). If you're coming from React, SvelteKit is similar to Next. If you're coming from Vue, SvelteKit is similar to Nuxt.
+SvelteKit est un <span class="vo">[framework](SVELTE_SITE_URL/docs/web#framework)</span> permettant de développer des applications web robustes et performantes avec [Svelte](SVELTE_SITE_URL). Si vous êtes habitué•e à React, SvelteKit est comparable à Next. Si vous êtes habitué•e à Vue, SvelteKit est comparable à Nuxt.
 
-To learn more about the kinds of applications you can build with SvelteKit, see the [FAQ](/docs/faq#what-can-i-make-with-sveltekit).
+Pour en apprendre plus sur les types d'application que vous pouvez construire avec SvelteKit, rendez-vous sur la [FàQ](/docs/faq#what-can-i-make-with-sveltekit)
 
-## What is Svelte?
+## C'est quoi Svelte ?
 
-In short, Svelte is a way of writing user interface components — like a navigation bar, comment section, or contact form — that users see and interact with in their browsers. The Svelte compiler converts your components to JavaScript that can be run to render the HTML for the page and to CSS that styles the page. You don't need to know Svelte to understand the rest of this guide, but it will help. If you'd like to learn more, check out [the Svelte tutorial](https://svelte.dev/tutorial).
+Pour faire court, Svelte est un moyen d'écrire des composants d'interface visuelle — comme une barre de navigation, une section de commentaires, ou un formulaire de contact — que les utilisateurs et utilisatrices voient et utilisent dans leurs navigateurs. Le compilateur Svelte convertit vos composants en du code JavaScript qui peut être exécuté pour afficher le HTML des pages, ainsi qu'en CSS qui applique le style des pages. Vous n'avez pas besoin de connaître Svelte pour comprendre le reste de ce guide, mais cela peut définitivement aider. Si vous souhaitez en savoir plus, n'hésitez pas à aller faire le [tutoriel dédié à Svelte](SVELTE_SITE_URL/tutorial)
 
 ## SvelteKit vs Svelte
 
-Svelte renders UI components. You can compose these components and render an entire page with just Svelte, but you need more than just Svelte to write an entire app.
+Svelte affiche des composants visuels. Vous pouvez composer ces composants et construire des pages entières juste avec Svelte, mais vous aurez besoin d'autres outils que Svelte pour construire une application complète.
 
-SvelteKit provides basic functionality like a [router](glossary#routing) — which updates the UI when a link is clicked — and [server-side rendering (SSR)](glossary#ssr). But beyond that, building an app with all the modern best practices is fiendishly complicated. Those practices include [build optimizations](https://vitejs.dev/guide/features.html#build-optimizations), so that you load only the minimal required code; [offline support](service-workers); [preloading](link-options#data-sveltekit-preload-data) pages before the user initiates navigation; [configurable rendering](page-options) that allows you to render different parts of your app on the server with [SSR](glossary#ssr), in the browser [client-side rendering](glossary#csr), or at build-time with [prerendering](glossary#prerendering); and many other things. SvelteKit does all the boring stuff for you so that you can get on with the creative part.
+SvelteKit fournit des fonctionnalités de base comme un [routeur](glossary#routing) — qui met à jour l'interface lorsqu'un lien est cliqué — et du [rendu côté serveur (SSR)](glossary#ssr). Mais au-delà de ces fonctionnalités, construire une application avec tous les outils et bonnes pratiques modernes est affreusement compliqué. Par exemple, l'[optimisation des builds](https://vitejs.dev/guide/features.html#build-optimizations), afin de ne charger que la quantité de code strictement nécessaire ; le [support hors-ligne](service-workers) ; le [pré-chargement](link-options#data-sveltekit-preload-data) des pages avant que la navigation ne soit initiée ; la [configuration de rendu](page-options) qui vous permet de construire différents morceaux de votre application sur le serveur avec du [SSR](glossary#ssr), dans le navigateur avec du [rendu côté client](glossary#csr), ou au moment de la compilation avec du [pré-rendu](glossary#prerendering) ; et bien d'autres choses. SvelteKit s'occupe de toutes ces choses pénibles afin que vous vous concentriez sur les parties plus créatives.
 
-It reflects changes to your code in the browser instantly to provide a lightning-fast and feature-rich development experience by leveraging [Vite](https://vitejs.dev/) with a [Svelte plugin](https://github.com/sveltejs/vite-plugin-svelte) to do [Hot Module Replacement (HMR)](https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/config.md#hot).
+SvelteKit reflète les changements de votre code instantanément dans le navigateur pour vous offrir une expérience de développement riche et efficace en utilisant [Vite](https://vitejs.dev/) au travers d'un [plugin Svelte](https://github.com/sveltejs/vite-plugin-svelte), permettant ainsi le [Hot Module Replacement (HMR)](https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/config.md#hot).

--- a/documentation/docs/10-getting-started/20-creating-a-project.md
+++ b/documentation/docs/10-getting-started/20-creating-a-project.md
@@ -11,7 +11,7 @@ npm install
 npm run dev
 ```
 
-La première commande va préparer un nouveau projet dans le dossier `my-app`, en vous proposant d'utiliser de l'outillage de base comme TypeScript.
+La première commande va générer un nouveau projet dans le dossier `my-app`, en vous proposant d'utiliser de l'outillage de base comme TypeScript.
 Vous trouverez des indications pour installer d'autres outils sur la page d'[intégrations](./integrations). Les autres commandes installent ensuite les dépendances du projet, et lancent un serveur de développement sur [localhost:5173](http://localhost:5173).
 
 SvelteKit a deux principes de base :

--- a/documentation/docs/10-getting-started/20-creating-a-project.md
+++ b/documentation/docs/10-getting-started/20-creating-a-project.md
@@ -2,7 +2,7 @@
 title: Créer un projet
 ---
 
-La façon la plus simple de commencer à construire une application SvelteKit est d'utiliser `npm create` :
+La façon la plus simple de commencer une application SvelteKit est d'utiliser `npm create` :
 
 ```bash
 npm create svelte@latest my-app

--- a/documentation/docs/10-getting-started/20-creating-a-project.md
+++ b/documentation/docs/10-getting-started/20-creating-a-project.md
@@ -16,7 +16,7 @@ Vous trouverez des indications pour installer d'autres outils sur la page d'[int
 
 SvelteKit a deux principes de base :
 
-- Chaque page de votre application est un composant [Svelte](SVELTE_SITE_URL)
+- Chaque page de votre application est un composant [Svelte](PUBLIC_SVELTE_SITE_URL)
 - Vous créez des pages en ajoutant des fichiers dans le dossier `src/routes` de votre projet. Ces pages seront d'abord rendues sur le serveur afin que la première visite d'un utilisateur ou d'une utilisatrice soit aussi rapide que possible, puis une application côté client prend le relais
 
 Essayez de modifier les fichiers pour vous faire une idée de comment les choses fonctionnent.

--- a/documentation/docs/10-getting-started/20-creating-a-project.md
+++ b/documentation/docs/10-getting-started/20-creating-a-project.md
@@ -1,8 +1,8 @@
 ---
-title: Creating a project
+title: Créer un projet
 ---
 
-The easiest way to start building a SvelteKit app is to run `npm create`:
+La façon la plus simple de commencer à construire une application SvelteKit est d'utiliser `npm create` :
 
 ```bash
 npm create svelte@latest my-app
@@ -11,15 +11,17 @@ npm install
 npm run dev
 ```
 
-The first command will scaffold a new project in the `my-app` directory asking you if you'd like to set up some basic tooling such as TypeScript. See [integrations](./integrations) for pointers on setting up additional tooling. The subsequent commands will then install its dependencies and start a server on [localhost:5173](http://localhost:5173).
+La première commande va préparer un nouveau projet dans le dossier `my-app`, en vous proposant d'utiliser de l'outillage de base comme TypeScript.
+Vous trouverez des indications pour installer d'autres outils sur la page d'[intégrations](./integrations). Les autres commandes installent ensuite les dépendances du projet, et lancent un serveur de développement sur [localhost:5173](http://localhost:5173).
 
-There are two basic concepts:
+SvelteKit a deux principes de base :
 
-- Each page of your app is a [Svelte](https://svelte.dev) component
-- You create pages by adding files to the `src/routes` directory of your project. These will be server-rendered so that a user's first visit to your app is as fast as possible, then a client-side app takes over
+- Chaque page de votre application est un composant [Svelte](SVELTE_SITE_URL)
+- Vous créez des pages en ajoutant des fichiers dans le dossier `src/routes` de votre projet. Ces pages seront d'abord rendues sur le serveur afin que la première visite d'un utilisateur ou d'une utilisatrice soit aussi rapide que possible, puis une application côté client prend le relais
 
-Try editing the files to get a feel for how everything works.
+Essayez de modifier les fichiers pour vous faire une idée de comment les choses fonctionnent.
 
-## Editor setup
+## Éditeurs
 
-We recommend using [Visual Studio Code (aka VS Code)](https://code.visualstudio.com/download) with [the Svelte extension](https://marketplace.visualstudio.com/items?itemName=svelte.svelte-vscode), but [support also exists for numerous other editors](https://sveltesociety.dev/tools#editor-support).
+Il est recommandé d'utiliser [Visual Studio Code (aka VS Code)](https://code.visualstudio.com/download) avec [l'extension Svelte](https://marketplace.visualstudio.com/items?itemName=svelte.svelte-vscode), mais [d'autres éditeurs sont également supportés](https://sveltesociety.dev/tools#editor-support).
+

--- a/documentation/docs/10-getting-started/30-project-structure.md
+++ b/documentation/docs/10-getting-started/30-project-structure.md
@@ -9,7 +9,7 @@ my-project/
 ├ src/
 │ ├ lib/
 │ │ ├ server/
-│ │ │ └ [vos fichiers spécifiques serveur]
+│ │ │ └ [vos fichiers spécifiques de serveur]
 │ │ └ [vos fichiers utilitaires]
 │ ├ params/
 │ │ └ [vos validateurs de paramètres]

--- a/documentation/docs/10-getting-started/30-project-structure.md
+++ b/documentation/docs/10-getting-started/30-project-structure.md
@@ -1,91 +1,91 @@
 ---
-title: Project structure
+title: Structure du project
 ---
 
-A typical SvelteKit project looks like this:
+Un projet typique SvelteKit ressemble à ceci :
 
 ```bash
 my-project/
 ├ src/
 │ ├ lib/
 │ │ ├ server/
-│ │ │ └ [your server-only lib files]
-│ │ └ [your lib files]
+│ │ │ └ [vos fichiers spécifiques serveur]
+│ │ └ [vos fichiers utilitaires]
 │ ├ params/
-│ │ └ [your param matchers]
+│ │ └ [vos validateurs de paramètres]
 │ ├ routes/
-│ │ └ [your routes]
+│ │ └ [vos routes]
 │ ├ app.html
 │ ├ error.html
 │ ├ hooks.client.js
 │ └ hooks.server.js
 ├ static/
-│ └ [your static assets]
+│ └ [vos fichiers statiques]
 ├ tests/
-│ └ [your tests]
+│ └ [vos tests]
 ├ package.json
 ├ svelte.config.js
 ├ tsconfig.json
 └ vite.config.js
 ```
 
-You'll also find common files like `.gitignore` and `.npmrc` (and `.prettierrc` and `.eslintrc.cjs` and so on, if you chose those options when running `npm create svelte@latest`).
+Vous trouverez aussi des fichiers classiques comme `.gitignore` et `.npmrc` (et `.prettierrc` et `.eslintrc.cjs` etc., si vous choisissez ces options lors de l'exécution de `npm create svelte@latest`).
 
-## Project files
+## Fichiers de projet
 
 ### src
 
-The `src` directory contains the meat of your project. Everything except `src/routes` and `src/app.html` is optional.
+Le dossier `src` contient le coeur de votre projet. Tout est optionnel, à l'exception de `src/routes` et `src/app.html`.
 
-- `lib` contains your library code (utilities and components), which can be imported via the [`$lib`](modules#$lib) alias, or packaged up for distribution using [`svelte-package`](packaging)
-  - `server` contains your server-only library code. It can be imported by using the [`$lib/server`](server-only-modules) alias. SvelteKit will prevent you from importing these in client code.
-- `params` contains any [param matchers](advanced-routing#matching) your app needs
-- `routes` contains the [routes](routing) of your application. You can also colocate other components that are only used within a single route here
-- `app.html` is your page template — an HTML document containing the following placeholders:
-  - `%sveltekit.head%` — `<link>` and `<script>` elements needed by the app, plus any `<svelte:head>` content
-  - `%sveltekit.body%` — the markup for a rendered page. This should live inside a `<div>` or other element, rather than directly inside `<body>`, to prevent bugs caused by browser extensions injecting elements that are then destroyed by the hydration process. SvelteKit will warn you in development if this is not the case
-  - `%sveltekit.assets%` — either [`paths.assets`](configuration#paths), if specified, or a relative path to [`paths.base`](configuration#paths)
-  - `%sveltekit.nonce%` — a [CSP](configuration#csp) nonce for manually included links and scripts, if used
-  - `%sveltekit.env.[NAME]%` - this will be replaced at render time with the `[NAME]` environment variable, which must begin with the [`publicPrefix`](configuration#env) (usually `PUBLIC_`). It will fallback to `''` if not matched.
-- `error.html` is the page that is rendered when everything else fails. It can contain the following placeholders:
-  - `%sveltekit.status%` — the HTTP status
-  - `%sveltekit.error.message%` — the error message
-- `hooks.client.js` contains your client [hooks](hooks)
-- `hooks.server.js` contains your server [hooks](hooks)
-- `service-worker.js` contains your [service worker](service-workers)
+- `lib` contient votre code de bibliothèque (utilitaires et composants), qui peut être importé via l'alias [`$lib`](modules#$lib) alias, ou <span class="vo">[packagé](SVELTE_SITE_URL/docs/web#bundler-packager)</span> pour être distribué en utilisant [`svelte-package`](packaging)
+	- `server` contient votre code de bibliothèque spécifique au serveur. Il peut être importé via l'alias [`$lib/server`](server-only-modules). SvelteKit vous empêchera d'importer ces fichiers dans du code client
+- `params` contient les [validateurs de paramètres](advanced-routing#matching) dont votre application a besoin
+- `routes` contient les [routes](routing) de votre application. Vous pouvez aussi y placer des composants qui ne sont utilisés que dans une seule route
+- `app.html` est votre <span class="vo">[template](SVELTE_SITE_URL/docs/development#template)</span> de page — un document HTML contenant les emplacements réservés suivants :
+  - `%sveltekit.head%` — les éléments `<link>` et `<script>` requis par votre application, plus tout contenu `<svelte:head>` éventuel
+  - `%sveltekit.body%` — le <span class="vo">[markup](SVELTE_SITE_URL/docs/web#markup)</span> d'une page. Ce contenu devrait être placé à l'intérieur d'une `<div>` ou tout autre élément, plutôt que directement dans le `<body>`, pour éviter des <span class="vo">[bugs](SVELTE_SITE_URL/docs/development#bug)</span> liés à certaines extensions navigateurs qui y injectent des éléments qui seront ensuite détruits par le processus d'hydratation. SvelteKit vous préviendra pendant le développement si ce n'est pas le cas
+  - `%sveltekit.assets%` — [`paths.assets`](configuration#paths) si précisé, ou un chemin relatif à [`paths.base`](configuration#paths)
+  - `%sveltekit.nonce%` — une configuration [CSP](configuration#csp) `nonce` pour les scripts et liens manuellement inclus, si nécessaire
+  - `%sveltekit.env.[NAME]%` - ceci sera remplacé au moment du rendu par la variable d'environnement `[NAME]`, qui doit commencer par le préfixe [`publicPrefix`](configuration#env) (en général `PUBLIC_`). Le défaut `''` sera appliqué si ce n'est pas le cas.
+- `error.html` est la page qui est affichée lorsque tout le reste s'écroule. Elle peut contenir les emplacements réservés suivants :
+  - `%sveltekit.status%` — le statut HTTP
+  - `%sveltekit.error.message%` — le message d'erreur
+- `hooks.client.js` contient vos [hooks](hooks) client
+- `hooks.server.js` contient vos [hooks](hooks) serveur
+- `service-worker.js` contient vos [service workers](service-workers)
 
-(Whether the project contains `.js` or `.ts` files depends on whether you opt to use TypeScript when you create your project. You can switch between JavaScript and TypeScript in the documentation using the toggle at the bottom of this page.)
+(Le fait d'utiliser les extensions de fichier `.js` ou `.ts` dépend de si vous décidez d'utiliser TypeScript lorsque vous créez votre projet. Vous pouvez passer de JavaScript à TypeScript dans la documentation en utilisant le bouton en bas de cette page.)
 
-If you added [Vitest](https://vitest.dev) when you set up your project, your unit tests will live in the `src` directory with a `.test.js` extension.
+Si vous avez ajouté [Vitest](https://vitest.dev) à l'installation du projet, vos tests unitaires seront à placer dans le dossier `src` avec une extension `.test.js`.
 
 ### static
 
-Any static assets that should be served as-is, like `robots.txt` or `favicon.png`, go in here.
+Tout fichier statique qui doit être servi tel quel, comme `robots.txt` ou `favicon.png`, sont placés ici.
 
 ### tests
 
-If you added [Playwright](https://playwright.dev/) for browser testing when you set up your project, the tests will live in this directory.
+Si vous avez ajouté [Playwright](https://playwright.dev/) lors de l'installation du projet, afin de tester votre application dans un navigateur, vous devrez placer ces tests dans ce dossier.
 
 ### package.json
 
-Your `package.json` file must include `@sveltejs/kit`, `svelte` and `vite` as `devDependencies`.
+Votre fichier `package.json` doit inclure `@sveltejs/kit`, `svelte` et `vite` en tant que `devDependencies`.
 
-When you create a project with `npm create svelte@latest`, you'll also notice that `package.json` includes `"type": "module"`. This means that `.js` files are interpreted as native JavaScript modules with `import` and `export` keywords. Legacy CommonJS files need a `.cjs` file extension.
+Lorsque vous créez un projet avec `npm create svelte@latest`, votre `package.json` inclut également `"type": "module"`. Cela signifie que les fichiers `.js` sont interprétés comme des modules JavaScript avec les mots-clés `import` et `export`. Les fichiers utilisant l'ancienne syntaxe CommonJS nécessitent une extension `.cjs`.
 
 ### svelte.config.js
 
-This file contains your Svelte and SvelteKit [configuration](configuration).
+Ce fichier contient votre [configuration](configuration) Svelte et SvelteKit.
 
 ### tsconfig.json
 
-This file (or `jsconfig.json`, if you prefer type-checked `.js` files over `.ts` files) configures TypeScript, if you added typechecking during `npm create svelte@latest`. Since SvelteKit relies on certain configuration being set a specific way, it generates its own `.svelte-kit/tsconfig.json` file which your own config `extends`.
+Ce fichier (ou `jsconfig.json` si vous préférez vérifier le typage dans des fichiers `.js` plutôt que `.ts`) configure TypeScript, si vous avez activé la vérification de type durant `npm create svelte@latest`. Puisque SvelteKit a besoin d'une certaine configuration, il génère son propre fichier `.svelte-kit/tsconfig.json` sur laquelle s'appuie votre propre configuration via `extends`.
 
 ### vite.config.js
 
-A SvelteKit project is really just a [Vite](https://vitejs.dev) project that uses the [`@sveltejs/kit/vite`](modules#sveltejs-kit-vite) plugin, along with any other [Vite configuration](https://vitejs.dev/config/).
+Un project SvelteKit est en réalité un projet [Vite](https://vitejs.dev) qui utilise le <span class="vo">[plugin](SVELTE_SITE_URL/docs/development#plugin)</span> [`@sveltejs/kit/vite`](modules#sveltejs-kit-vite) en plus de toute autre [configuration Vite](https://vitejs.dev/config/) éventuelle.
 
-## Other files
+## Autres fichiers
 
 ### .svelte-kit
 
-As you develop and build your project, SvelteKit will generate files in a `.svelte-kit` directory (configurable as [`outDir`](configuration#outdir)). You can ignore its contents, and delete them at any time (they will be regenerated when you next `dev` or `build`).
+Au fur et à mesure que vous avancerez dans le développement de votre projet, SvelteKit va générer des fichiers dans un dossier `.svelte-kit` (configurable en tant que [`outDir`](configuration#outdir)). Vous pouvez ignorer son contenu, et le supprimer à tout moment (il sera regénéré lors de votre prochaine utilisation de `dev` ou `build`)

--- a/documentation/docs/10-getting-started/30-project-structure.md
+++ b/documentation/docs/10-getting-started/30-project-structure.md
@@ -37,13 +37,13 @@ Vous trouverez aussi des fichiers classiques comme `.gitignore` et `.npmrc` (et 
 
 Le dossier `src` contient le coeur de votre projet. Tout est optionnel, à l'exception de `src/routes` et `src/app.html`.
 
-- `lib` contient votre code de bibliothèque (utilitaires et composants), qui peut être importé via l'alias [`$lib`](modules#$lib) alias, ou <span class="vo">[packagé](SVELTE_SITE_URL/docs/web#bundler-packager)</span> pour être distribué en utilisant [`svelte-package`](packaging)
+- `lib` contient votre code de bibliothèque (utilitaires et composants), qui peut être importé via l'alias [`$lib`](modules#$lib) alias, ou <span class="vo">[packagé](PUBLIC_SVELTE_SITE_URL/docs/web#bundler-packager)</span> pour être distribué en utilisant [`svelte-package`](packaging)
 	- `server` contient votre code de bibliothèque spécifique au serveur. Il peut être importé via l'alias [`$lib/server`](server-only-modules). SvelteKit vous empêchera d'importer ces fichiers dans du code client
 - `params` contient les [validateurs de paramètres](advanced-routing#matching) dont votre application a besoin
 - `routes` contient les [routes](routing) de votre application. Vous pouvez aussi y placer des composants qui ne sont utilisés que dans une seule route
-- `app.html` est votre <span class="vo">[template](SVELTE_SITE_URL/docs/development#template)</span> de page — un document HTML contenant les emplacements réservés suivants :
+- `app.html` est votre <span class="vo">[template](PUBLIC_SVELTE_SITE_URL/docs/development#template)</span> de page — un document HTML contenant les emplacements réservés suivants :
   - `%sveltekit.head%` — les éléments `<link>` et `<script>` requis par votre application, plus tout contenu `<svelte:head>` éventuel
-  - `%sveltekit.body%` — le <span class="vo">[markup](SVELTE_SITE_URL/docs/web#markup)</span> d'une page. Ce contenu devrait être placé à l'intérieur d'une `<div>` ou tout autre élément, plutôt que directement dans le `<body>`, pour éviter des <span class="vo">[bugs](SVELTE_SITE_URL/docs/development#bug)</span> liés à certaines extensions navigateurs qui y injectent des éléments qui seront ensuite détruits par le processus d'hydratation. SvelteKit vous préviendra pendant le développement si ce n'est pas le cas
+  - `%sveltekit.body%` — le <span class="vo">[markup](PUBLIC_SVELTE_SITE_URL/docs/web#markup)</span> d'une page. Ce contenu devrait être placé à l'intérieur d'une `<div>` ou tout autre élément, plutôt que directement dans le `<body>`, pour éviter des <span class="vo">[bugs](PUBLIC_SVELTE_SITE_URL/docs/development#bug)</span> liés à certaines extensions navigateurs qui y injectent des éléments qui seront ensuite détruits par le processus d'hydratation. SvelteKit vous préviendra pendant le développement si ce n'est pas le cas
   - `%sveltekit.assets%` — [`paths.assets`](configuration#paths) si précisé, ou un chemin relatif à [`paths.base`](configuration#paths)
   - `%sveltekit.nonce%` — une configuration [CSP](configuration#csp) `nonce` pour les scripts et liens manuellement inclus, si nécessaire
   - `%sveltekit.env.[NAME]%` - ceci sera remplacé au moment du rendu par la variable d'environnement `[NAME]`, qui doit commencer par le préfixe [`publicPrefix`](configuration#env) (en général `PUBLIC_`). Le défaut `''` sera appliqué si ce n'est pas le cas.
@@ -82,7 +82,7 @@ Ce fichier (ou `jsconfig.json` si vous préférez vérifier le typage dans des f
 
 ### vite.config.js
 
-Un project SvelteKit est en réalité un projet [Vite](https://vitejs.dev) qui utilise le <span class="vo">[plugin](SVELTE_SITE_URL/docs/development#plugin)</span> [`@sveltejs/kit/vite`](modules#sveltejs-kit-vite) en plus de toute autre [configuration Vite](https://vitejs.dev/config/) éventuelle.
+Un project SvelteKit est en réalité un projet [Vite](https://vitejs.dev) qui utilise le <span class="vo">[plugin](PUBLIC_SVELTE_SITE_URL/docs/development#plugin)</span> [`@sveltejs/kit/vite`](modules#sveltejs-kit-vite) en plus de toute autre [configuration Vite](https://vitejs.dev/config/) éventuelle.
 
 ## Autres fichiers
 

--- a/documentation/docs/10-getting-started/30-project-structure.md
+++ b/documentation/docs/10-getting-started/30-project-structure.md
@@ -42,7 +42,7 @@ Le dossier `src` contient le coeur de votre projet. Tout est optionnel, à l'exc
 - `params` contient les [validateurs de paramètres](advanced-routing#matching) dont votre application a besoin
 - `routes` contient les [routes](routing) de votre application. Vous pouvez aussi y placer des composants qui ne sont utilisés que dans une seule route
 - `app.html` est votre <span class="vo">[template](PUBLIC_SVELTE_SITE_URL/docs/development#template)</span> de page — un document HTML contenant les emplacements réservés suivants :
-  - `%sveltekit.head%` — les éléments `<link>` et `<script>` requis par votre application, plus tout contenu `<svelte:head>` éventuel
+  - `%sveltekit.head%` — les éléments `<link>` et `<script>` requis par votre application, ainsi que le contenu `<svelte:head>` éventuel
   - `%sveltekit.body%` — le <span class="vo">[markup](PUBLIC_SVELTE_SITE_URL/docs/web#markup)</span> d'une page. Ce contenu devrait être placé à l'intérieur d'une `<div>` ou tout autre élément, plutôt que directement dans le `<body>`, pour éviter des <span class="vo">[bugs](PUBLIC_SVELTE_SITE_URL/docs/development#bug)</span> liés à certaines extensions navigateurs qui y injectent des éléments qui seront ensuite détruits par le processus d'hydratation. SvelteKit vous préviendra pendant le développement si ce n'est pas le cas
   - `%sveltekit.assets%` — [`paths.assets`](configuration#paths) si précisé, ou un chemin relatif à [`paths.base`](configuration#paths)
   - `%sveltekit.nonce%` — une configuration [CSP](configuration#csp) `nonce` pour les scripts et liens manuellement inclus, si nécessaire

--- a/documentation/docs/10-getting-started/40-web-standards.md
+++ b/documentation/docs/10-getting-started/40-web-standards.md
@@ -1,32 +1,32 @@
 ---
-title: Web standards
+title: Standards du web
 ---
 
-Throughout this documentation, you'll see references to the standard [Web APIs](https://developer.mozilla.org/en-US/docs/Web/API) that SvelteKit builds on top of. Rather than reinventing the wheel, we _use the platform_, which means your existing web development skills are applicable to SvelteKit. Conversely, time spent learning SvelteKit will help you be a better web developer elsewhere.
+Tout au long de cette documentation, vous trouverez des références aux [APIs Web](https://developer.mozilla.org/fr/docs/Web/API) standards sur lesquelles s'appuie SvelteKit. Plutôt que de réinventer la roue, SvelteKit _utilise la plateforme_, ce qui signifie que vos compétences en développement web sont utilisables avec SvelteKit. De même, le temps passé à apprendre SvelteKit vous aidera à progresser en tant que développeur ou développeuse web de manière générale.
 
-These APIs are available in all modern browsers and in many non-browser environments like Cloudflare Workers, Deno and Vercel Edge Functions. During development, and in [adapters](adapters) for Node-based environments (including AWS Lambda), they're made available via polyfills where necessary (for now, that is — Node is rapidly adding support for more web standards).
+Ces <span class="vo">[APIs](SVELTE_SITE_URL/docs/development#api)</span> sont disponibles dans tous les navigateurs modernes et dans de nombreux environnements hors navigateur, comme les "Cloudflare Workers", ou les "Edge Functions" de Deno et Vercel. Pendant le développement, et au sein des [adaptateurs](adapters) d'environnement Node (dont AWS Lambda), elles sont rendues disponibles via des <span class="vo">[polyfills](SVELTE_SITE_URL/docs/javascript#polyfill)</span> lorsque nécessaire (en tout cas pour le moment — Node ajoute de plus en plus de standards web).
 
-In particular, you'll get comfortable with the following:
+En particulier, vous deviendrez familier•e•s avec :
 
-## Fetch APIs
+## APIs Fetch
 
-SvelteKit uses [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/fetch) for getting data from the network. It's available in [hooks](hooks) and [server routes](routing#server) as well as in the browser.
+Svelte utilise [`fetch`](https://developer.mozilla.org/fr/docs/Web/API/fetch) pour récupérer la donnée du réseau. Cette méthode est disponible dans les [hooks](hooks) et les [routes serveur](routing#server) ainsi que dans le navigateur.
 
-> A special version of `fetch` is available in [`load`](load) functions, [server hooks](hooks#server-hooks) and [API routes](routing#server) for invoking endpoints directly during server-side rendering, without making an HTTP call, while preserving credentials. (To make credentialled fetches in server-side code outside `load`, you must explicitly pass `cookie` and/or `authorization` headers.) It also allows you to make relative requests, whereas server-side `fetch` normally requires a fully qualified URL.
+> Une version spéciale de `fetch` est disponible dans les fonctions [`load`](load), dans les [hooks server](hooks#server-hooks), ainsi que dans les [routes d'API serveur](routing#server) pour appeler des <span class="vo">[endpoints](SVELTE_SITE_URL/docs/web#endpoint)</span> directement lors du rendu côté serveur, sans faire d'appel HTTP tout en préservant les identifiants. (Pour faire des appels identifiés dans du code serveur en dehors de `load`, vous devez explicitement passer des <span class="vo">[headers](SVELTE_SITE_URL/docs/web#header)</span> `cookie` et/ou `authorization`.) Elle vous permet également de faire des requêtes relatives, là où un `fetch` côté serveur vous impose normalement une URL complète.
 
-Besides `fetch` itself, the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) includes the following interfaces:
+En plus de `fetch`, l'[API Fetch](https://developer.mozilla.org/fr/docs/Web/API/Fetch_API) inclut les interfaces suivantes :
 
 ### Request
 
-An instance of [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) is accessible in [hooks](hooks) and [server routes](routing#server) as `event.request`. It contains useful methods like `request.json()` and `request.formData()` for getting data that was posted to an endpoint.
+Une instance de [`Request`](https://developer.mozilla.org/fr/docs/Web/API/Request) est accessible dans les [hooks](hooks) et les [routes serveur](routing#server) en tant que `event.request`. Elle contient des méthodes utiles comme `request.json()` et `request.formData()` pour récupérer la donnée envoyée au <span class="vo">[endpoint](SVELTE_SITE_URL/docs/web#endpoint)</span>.
 
 ### Response
 
-An instance of [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response) is returned from `await fetch(...)` and handlers in `+server.js` files. Fundamentally, a SvelteKit app is a machine for turning a `Request` into a `Response`.
+Une instance de [`Response`](https://developer.mozilla.org/fr/docs/Web/API/Response) est renvoyée de `await fetch(...)` et des fonctions des fichiers `+server.js`. Au fond, une application SvelteKit est une machine à tranformer une `Request` en `Response`.
 
 ### Headers
 
-The [`Headers`](https://developer.mozilla.org/en-US/docs/Web/API/Headers) interface allows you to read incoming `request.headers` and set outgoing `response.headers`. For example, you can get the `request.headers` as shown below, and use the [`json` convenience function](modules#sveltejs-kit-json) to send modified `response.headers`:
+L'interface [`Headers`](https://developer.mozilla.org/fr/docs/Web/API/Headers) vous permet de lire les `request.headers` entrants et de définir des `response.headers` sortants. Par exemple, vous pouvez récupérer les `request.headers` comme montré ci-dessous, et utiliser la [fonction utilitaire `json`](modules#sveltejs-kit-json) pour envoyer des `response.headers` modifiés :
 
 ```js
 // @errors: 2461
@@ -35,15 +35,15 @@ import { json } from '@sveltejs/kit';
 
 /** @type {import('./$types').RequestHandler} */
 export function GET({ request }) {
-	// log all headers
+	// affiche tous les headers
 	console.log(...request.headers);
 
-	// create a JSON Response using a header we received
+	// crée une Response JSON en utilisant un header reçu
 	return json({
-		// retrieve a specific header
+		// récupère un header spécifique
 		userAgent: request.headers.get('user-agent')
 	}, {
-		// set a header on the response
+		// définit un header sur la réponse
 		headers: { 'x-custom-header': 'potato' }
 	});
 }
@@ -51,7 +51,7 @@ export function GET({ request }) {
 
 ## FormData
 
-When dealing with HTML native form submissions you'll be working with [`FormData`](https://developer.mozilla.org/en-US/docs/Web/API/FormData) objects.
+Lorsque vous recevez des soumissions natives de formulaire HTML, vous avez affaire avec des objets [`FormData`](https://developer.mozilla.org/fr/docs/Web/API/FormData).
 
 ```js
 // @errors: 2461
@@ -62,27 +62,27 @@ import { json } from '@sveltejs/kit';
 export async function POST(event) {
 	const body = await event.request.formData();
 
-	// log all fields
+	// affiche tous les champs
 	console.log([...body]);
 
 	return json({
-		// get a specific field's value
+		// récupère une valeur spécifique
 		name: body.get('name') ?? 'world'
 	});
 }
 ```
 
-## Stream APIs
+## APIs de Stream
 
-Most of the time, your endpoints will return complete data, as in the `userAgent` example above. Sometimes, you may need to return a response that's too large to fit in memory in one go, or is delivered in chunks, and for this the platform provides [streams](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API) — [ReadableStream](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream), [WritableStream](https://developer.mozilla.org/en-US/docs/Web/API/WritableStream) and [TransformStream](https://developer.mozilla.org/en-US/docs/Web/API/TransformStream).
+La plupart du temps, vos <span class="vo">[endpoints](SVELTE_SITE_URL/docs/web#endpoint)</span> vous renverront de la donnée complète, comme dans l'exemple `userAgent` ci-dessus. Parfois, vous pourriez avoir besoin de renvoyer une réponse trop lourde pour être envoyée en une seule fois, ou de renvoyer la donnée en morceaux, et pour cela la plateforme fournit des [streams](https://developer.mozilla.org/fr/docs/Web/API/Streams_API) — [ReadableStream](https://developer.mozilla.org/fr/docs/Web/API/ReadableStream), [WritableStream](https://developer.mozilla.org/fr/docs/Web/API/WritableStream) et [TransformStream](https://developer.mozilla.org/fr/docs/Web/API/TransformStream).
 
-## URL APIs
+## APIs d'URL
 
-URLs are represented by the [`URL`](https://developer.mozilla.org/en-US/docs/Web/API/URL) interface, which includes useful properties like `origin` and `pathname` (and, in the browser, `hash`). This interface shows up in various places — `event.url` in [hooks](hooks) and [server routes](routing#server), [`$page.url`](modules#$app-stores) in [pages](routing#page), `from` and `to` in [`beforeNavigate` and `afterNavigate`](modules#$app-navigation) and so on.
+Les URLs sont représentées par l'interface [`URL`](https://developer.mozilla.org/fr/docs/Web/API/URL), qui inclut des propriétés utiles comme `origin` et `pathname` (et `hash` dans le navigateur). Cette interface est utilisée à différents endroits — `event.url` dans les [hooks](hooks) et les [routes de serveur](routing#server), [`$page.url`](modules#$app-stores) dans les [pages](routing#page), `from` et `to` dans les fonctions [`beforeNavigate` et `afterNavigate`](modules#$app-navigation) et ainsi de suite.
 
 ### URLSearchParams
 
-Wherever you encounter a URL, you can access query parameters via `url.searchParams`, which is an instance of [`URLSearchParams`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams):
+Peu importe où vous rencontrez une URL, vous pouvez toujours accéder aux paramètres de recherche via `url.searchParams`, qui est une instance de [`URLSearchParams`](https://developer.mozilla.org/fr/docs/Web/API/URLSearchParams) :
 
 ```js
 // @filename: ambient.d.ts
@@ -99,7 +99,7 @@ const foo = url.searchParams.get('foo');
 
 ## Web Crypto
 
-The [Web Crypto API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API) is made available via the `crypto` global. It's used internally for [Content Security Policy](configuration#csp) headers, but you can also use it for things like generating UUIDs:
+L'[API Web Crypto](https://developer.mozilla.org/fr/docs/Web/API/Web_Crypto_API) est rendue disponible via le module global `crypto`. Elle est utilisée en interne pour les <span class="vo">[headers](SVELTE_SITE_URL/docs/web#header)</span> de [Content Security Policy](configuration#csp), mais vous pouvez également vous en servir pour par exemple générer des identifiants UUIDs :
 
 ```js
 const uuid = crypto.randomUUID();

--- a/documentation/docs/10-getting-started/40-web-standards.md
+++ b/documentation/docs/10-getting-started/40-web-standards.md
@@ -4,7 +4,7 @@ title: Standards du web
 
 Tout au long de cette documentation, vous trouverez des références aux [APIs Web](https://developer.mozilla.org/fr/docs/Web/API) standards sur lesquelles s'appuie SvelteKit. Plutôt que de réinventer la roue, SvelteKit _utilise la plateforme_, ce qui signifie que vos compétences en développement web sont utilisables avec SvelteKit. De même, le temps passé à apprendre SvelteKit vous aidera à progresser en tant que développeur ou développeuse web de manière générale.
 
-Ces <span class="vo">[APIs](SVELTE_SITE_URL/docs/development#api)</span> sont disponibles dans tous les navigateurs modernes et dans de nombreux environnements hors navigateur, comme les "Cloudflare Workers", ou les "Edge Functions" de Deno et Vercel. Pendant le développement, et au sein des [adaptateurs](adapters) d'environnement Node (dont AWS Lambda), elles sont rendues disponibles via des <span class="vo">[polyfills](SVELTE_SITE_URL/docs/javascript#polyfill)</span> lorsque nécessaire (en tout cas pour le moment — Node ajoute de plus en plus de standards web).
+Ces <span class="vo">[APIs](PUBLIC_SVELTE_SITE_URL/docs/development#api)</span> sont disponibles dans tous les navigateurs modernes et dans de nombreux environnements hors navigateur, comme les "Cloudflare Workers", ou les "Edge Functions" de Deno et Vercel. Pendant le développement, et au sein des [adaptateurs](adapters) d'environnement Node (dont AWS Lambda), elles sont rendues disponibles via des <span class="vo">[polyfills](PUBLIC_SVELTE_SITE_URL/docs/javascript#polyfill)</span> lorsque nécessaire (en tout cas pour le moment — Node ajoute de plus en plus de standards web).
 
 En particulier, vous deviendrez familier•e•s avec :
 
@@ -12,13 +12,13 @@ En particulier, vous deviendrez familier•e•s avec :
 
 Svelte utilise [`fetch`](https://developer.mozilla.org/fr/docs/Web/API/fetch) pour récupérer la donnée du réseau. Cette méthode est disponible dans les [hooks](hooks) et les [routes serveur](routing#server) ainsi que dans le navigateur.
 
-> Une version spéciale de `fetch` est disponible dans les fonctions [`load`](load), dans les [hooks server](hooks#server-hooks), ainsi que dans les [routes d'API serveur](routing#server) pour appeler des <span class="vo">[endpoints](SVELTE_SITE_URL/docs/web#endpoint)</span> directement lors du rendu côté serveur, sans faire d'appel HTTP tout en préservant les identifiants. (Pour faire des appels identifiés dans du code serveur en dehors de `load`, vous devez explicitement passer des <span class="vo">[headers](SVELTE_SITE_URL/docs/web#header)</span> `cookie` et/ou `authorization`.) Elle vous permet également de faire des requêtes relatives, là où un `fetch` côté serveur vous impose normalement une URL complète.
+> Une version spéciale de `fetch` est disponible dans les fonctions [`load`](load), dans les [hooks server](hooks#server-hooks), ainsi que dans les [routes d'API serveur](routing#server) pour appeler des <span class="vo">[endpoints](PUBLIC_SVELTE_SITE_URL/docs/web#endpoint)</span> directement lors du rendu côté serveur, sans faire d'appel HTTP tout en préservant les identifiants. (Pour faire des appels identifiés dans du code serveur en dehors de `load`, vous devez explicitement passer des <span class="vo">[headers](PUBLIC_SVELTE_SITE_URL/docs/web#header)</span> `cookie` et/ou `authorization`.) Elle vous permet également de faire des requêtes relatives, là où un `fetch` côté serveur vous impose normalement une URL complète.
 
 En plus de `fetch`, l'[API Fetch](https://developer.mozilla.org/fr/docs/Web/API/Fetch_API) inclut les interfaces suivantes :
 
 ### Request
 
-Une instance de [`Request`](https://developer.mozilla.org/fr/docs/Web/API/Request) est accessible dans les [hooks](hooks) et les [routes serveur](routing#server) en tant que `event.request`. Elle contient des méthodes utiles comme `request.json()` et `request.formData()` pour récupérer la donnée envoyée au <span class="vo">[endpoint](SVELTE_SITE_URL/docs/web#endpoint)</span>.
+Une instance de [`Request`](https://developer.mozilla.org/fr/docs/Web/API/Request) est accessible dans les [hooks](hooks) et les [routes serveur](routing#server) en tant que `event.request`. Elle contient des méthodes utiles comme `request.json()` et `request.formData()` pour récupérer la donnée envoyée au <span class="vo">[endpoint](PUBLIC_SVELTE_SITE_URL/docs/web#endpoint)</span>.
 
 ### Response
 
@@ -74,7 +74,7 @@ export async function POST(event) {
 
 ## APIs de Stream
 
-La plupart du temps, vos <span class="vo">[endpoints](SVELTE_SITE_URL/docs/web#endpoint)</span> vous renverront de la donnée complète, comme dans l'exemple `userAgent` ci-dessus. Parfois, vous pourriez avoir besoin de renvoyer une réponse trop lourde pour être envoyée en une seule fois, ou de renvoyer la donnée en morceaux, et pour cela la plateforme fournit des [streams](https://developer.mozilla.org/fr/docs/Web/API/Streams_API) — [ReadableStream](https://developer.mozilla.org/fr/docs/Web/API/ReadableStream), [WritableStream](https://developer.mozilla.org/fr/docs/Web/API/WritableStream) et [TransformStream](https://developer.mozilla.org/fr/docs/Web/API/TransformStream).
+La plupart du temps, vos <span class="vo">[endpoints](PUBLIC_SVELTE_SITE_URL/docs/web#endpoint)</span> vous renverront de la donnée complète, comme dans l'exemple `userAgent` ci-dessus. Parfois, vous pourriez avoir besoin de renvoyer une réponse trop lourde pour être envoyée en une seule fois, ou de renvoyer la donnée en morceaux, et pour cela la plateforme fournit des [streams](https://developer.mozilla.org/fr/docs/Web/API/Streams_API) — [ReadableStream](https://developer.mozilla.org/fr/docs/Web/API/ReadableStream), [WritableStream](https://developer.mozilla.org/fr/docs/Web/API/WritableStream) et [TransformStream](https://developer.mozilla.org/fr/docs/Web/API/TransformStream).
 
 ## APIs d'URL
 
@@ -99,7 +99,7 @@ const foo = url.searchParams.get('foo');
 
 ## Web Crypto
 
-L'[API Web Crypto](https://developer.mozilla.org/fr/docs/Web/API/Web_Crypto_API) est rendue disponible via le module global `crypto`. Elle est utilisée en interne pour les <span class="vo">[headers](SVELTE_SITE_URL/docs/web#header)</span> de [Content Security Policy](configuration#csp), mais vous pouvez également vous en servir pour par exemple générer des identifiants UUID :
+L'[API Web Crypto](https://developer.mozilla.org/fr/docs/Web/API/Web_Crypto_API) est rendue disponible via le module global `crypto`. Elle est utilisée en interne pour les <span class="vo">[headers](PUBLIC_SVELTE_SITE_URL/docs/web#header)</span> de [Content Security Policy](configuration#csp), mais vous pouvez également vous en servir pour par exemple générer des identifiants UUID :
 
 ```js
 const uuid = crypto.randomUUID();

--- a/documentation/docs/10-getting-started/40-web-standards.md
+++ b/documentation/docs/10-getting-started/40-web-standards.md
@@ -99,7 +99,7 @@ const foo = url.searchParams.get('foo');
 
 ## Web Crypto
 
-L'[API Web Crypto](https://developer.mozilla.org/fr/docs/Web/API/Web_Crypto_API) est rendue disponible via le module global `crypto`. Elle est utilisée en interne pour les <span class="vo">[headers](SVELTE_SITE_URL/docs/web#header)</span> de [Content Security Policy](configuration#csp), mais vous pouvez également vous en servir pour par exemple générer des identifiants UUIDs :
+L'[API Web Crypto](https://developer.mozilla.org/fr/docs/Web/API/Web_Crypto_API) est rendue disponible via le module global `crypto`. Elle est utilisée en interne pour les <span class="vo">[headers](SVELTE_SITE_URL/docs/web#header)</span> de [Content Security Policy](configuration#csp), mais vous pouvez également vous en servir pour par exemple générer des identifiants UUID :
 
 ```js
 const uuid = crypto.randomUUID();

--- a/documentation/docs/10-getting-started/meta.json
+++ b/documentation/docs/10-getting-started/meta.json
@@ -1,3 +1,3 @@
 {
-	"title": "Getting started"
+	"title": "Bien commencer"
 }

--- a/documentation/docs/30-advanced/20-hooks.md
+++ b/documentation/docs/30-advanced/20-hooks.md
@@ -19,7 +19,7 @@ The following hooks can be added to `src/hooks.server.js`:
 
 ### handle
 
-This function runs every time the SvelteKit server receives a [request](web-standards#fetch-apis-request) — whether that happens while the app is running, or during [prerendering](page-options#prerender) — and determines the [response](web-standards#fetch-apis-response). It receives an `event` object representing the request and a function called `resolve`, which renders the route and generates a `Response`. This allows you to modify response headers or bodies, or bypass SvelteKit entirely (for implementing routes programmatically, for example).
+This function runs every time the SvelteKit server receives a [request](web-standards#apis-fetch-response) — whether that happens while the app is running, or during [prerendering](page-options#prerender) — and determines the [response](web-standards#apis-fetch-response). It receives an `event` object representing the request and a function called `resolve`, which renders the route and generates a `Response`. This allows you to modify response headers or bodies, or bypass SvelteKit entirely (for implementing routes programmatically, for example).
 
 ```js
 /// file: src/hooks.server.js

--- a/documentation/docs/30-advanced/20-hooks.md
+++ b/documentation/docs/30-advanced/20-hooks.md
@@ -19,7 +19,7 @@ The following hooks can be added to `src/hooks.server.js`:
 
 ### handle
 
-This function runs every time the SvelteKit server receives a [request](web-standards#apis-fetch-response) — whether that happens while the app is running, or during [prerendering](page-options#prerender) — and determines the [response](web-standards#apis-fetch-response). It receives an `event` object representing the request and a function called `resolve`, which renders the route and generates a `Response`. This allows you to modify response headers or bodies, or bypass SvelteKit entirely (for implementing routes programmatically, for example).
+This function runs every time the SvelteKit server receives a [request](web-standards#apis-fetch-request) — whether that happens while the app is running, or during [prerendering](page-options#prerender) — and determines the [response](web-standards#apis-fetch-response). It receives an `event` object representing the request and a function called `resolve`, which renders the route and generates a `Response`. This allows you to modify response headers or bodies, or bypass SvelteKit entirely (for implementing routes programmatically, for example).
 
 ```js
 /// file: src/hooks.server.js

--- a/documentation/docs/60-appendix/10-migrating.md
+++ b/documentation/docs/60-appendix/10-migrating.md
@@ -41,7 +41,7 @@ Your `webpack.config.js` or `rollup.config.js` should be replaced with a `svelte
 
 You will need to add an [adapter](adapters). `sapper build` is roughly equivalent to [adapter-node](https://github.com/sveltejs/kit/tree/master/packages/adapter-node) while `sapper export` is roughly equivalent to [adapter-static](https://github.com/sveltejs/kit/tree/master/packages/adapter-static), though you might prefer to use an adapter designed for the platform you're deploying to.
 
-If you were using plugins for filetypes that are not automatically handled by [Vite](https://vitejs.dev), you will need to find Vite equivalents and add them to the [Vite config](project-structure#project-files-vite-config-js).
+If you were using plugins for filetypes that are not automatically handled by [Vite](https://vitejs.dev), you will need to find Vite equivalents and add them to the [Vite config](project-structure#fichiers-de-projet-vite-config-js).
 
 ### src/client.js
 

--- a/sites/kit.svelte.dev/src/app.html
+++ b/sites/kit.svelte.dev/src/app.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="no-js">
+<html lang="fr" class="no-js">
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width" />

--- a/sites/kit.svelte.dev/src/lib/server/docs/index.js
+++ b/sites/kit.svelte.dev/src/lib/server/docs/index.js
@@ -12,7 +12,12 @@ import { readFile, readdir } from 'node:fs/promises';
 import { CONTENT_BASE_PATHS } from '../../../constants.js';
 import { render_content } from '../renderer';
 
-import { PUBLIC_SVELTE_SITE_URL, PUBLIC_LEARN_SITE_URL } from '$env/static/public';
+import {
+	PUBLIC_SVELTE_SITE_URL,
+	PUBLIC_KIT_SITE_URL,
+	PUBLIC_LEARN_SITE_URL,
+	PUBLIC_GITHUB_ORG
+} from '$env/static/public';
 
 /**
  * @param {import('./types').DocsData} docs_data
@@ -24,7 +29,9 @@ export async function get_parsed_docs(docs_data, slug) {
 			if (page.slug === slug) {
 				const content = page.content
 					.replace(/PUBLIC_SVELTE_SITE_URL/g, PUBLIC_SVELTE_SITE_URL)
-					.replace(/PUBLIC_LEARN_SITE_URL/g, PUBLIC_LEARN_SITE_URL);
+					.replace(/PUBLIC_KIT_SITE_URL/g, PUBLIC_KIT_SITE_URL)
+					.replace(/PUBLIC_LEARN_SITE_URL/g, PUBLIC_LEARN_SITE_URL)
+					.replace(/PUBLIC_GITHUB_ORG/g, PUBLIC_GITHUB_ORG);
 
 				return {
 					...page,

--- a/sites/kit.svelte.dev/src/lib/server/docs/index.js
+++ b/sites/kit.svelte.dev/src/lib/server/docs/index.js
@@ -12,7 +12,7 @@ import { readFile, readdir } from 'node:fs/promises';
 import { CONTENT_BASE_PATHS } from '../../../constants.js';
 import { render_content } from '../renderer';
 
-import { SVELTE_SITE_URL, LEARN_SITE_URL } from '$env/static/private';
+import { PUBLIC_SVELTE_SITE_URL, PUBLIC_LEARN_SITE_URL } from '$env/static/public';
 
 /**
  * @param {import('./types').DocsData} docs_data
@@ -23,8 +23,8 @@ export async function get_parsed_docs(docs_data, slug) {
 		for (const page of pages) {
 			if (page.slug === slug) {
 				const content = page.content
-					.replace(/SVELTE_SITE_URL/g, SVELTE_SITE_URL)
-					.replace(/LEARN_SITE_URL/g, LEARN_SITE_URL);
+					.replace(/PUBLIC_SVELTE_SITE_URL/g, PUBLIC_SVELTE_SITE_URL)
+					.replace(/PUBLIC_LEARN_SITE_URL/g, PUBLIC_LEARN_SITE_URL);
 
 				return {
 					...page,

--- a/sites/kit.svelte.dev/src/routes/+error.svelte
+++ b/sites/kit.svelte.dev/src/routes/+error.svelte
@@ -1,5 +1,6 @@
 <script>
 	import { page } from '$app/stores';
+	import { PUBLIC_SVELTE_SITE_URL } from '$env/static/public';
 
 	// we don't want to use <svelte:window bind:online> here, because we only care about the online
 	// state when the page first loads
@@ -12,25 +13,27 @@
 
 <div class="container">
 	{#if $page.status === 404}
-		<h1>Not found!</h1>
+		<h1>Non trouvé !</h1>
 	{:else if online}
-		<h1>Yikes!</h1>
+		<h1>Beurk !</h1>
 
 		{#if $page.error.message}
 			<p class="error">{$page.status}: {$page.error.message}</p>
 		{/if}
 
-		<p>Please try reloading the page.</p>
+		<p>Merci d'essayer de recharger la page.</p>
 
 		<p>
-			If the error persists, please drop by <a href="https://svelte.dev/chat">Discord chatroom</a>
-			and let us know, or raise an issue on
-			<a href="https://github.com/sveltejs/svelte">GitHub</a>. Thanks!
+			Si l'erreur persiste, merci de vous rendre sur le <a href="{PUBLIC_SVELTE_SITE_URL}/chat"
+				>forum Discord</a
+			>
+			et de nous remonter le problème, ou ouvrez une issue sur
+			<a href="https://github.com/svelte-society-fr/kit">GitHub</a>. Merci !
 		</p>
 	{:else}
-		<h1>It looks like you're offline</h1>
+		<h1>Il semblerait que vous soyez hors ligne</h1>
 
-		<p>Reload the page once you've found the internet.</p>
+		<p>Rechargez la page une fois que vous aurez retrouvé internet.</p>
 	{/if}
 </div>
 

--- a/sites/kit.svelte.dev/src/routes/+error.svelte
+++ b/sites/kit.svelte.dev/src/routes/+error.svelte
@@ -1,6 +1,6 @@
 <script>
 	import { page } from '$app/stores';
-	import { PUBLIC_SVELTE_SITE_URL } from '$env/static/public';
+	import { PUBLIC_SVELTE_SITE_URL, PUBLIC_GITHUB_ORG } from '$env/static/public';
 
 	// we don't want to use <svelte:window bind:online> here, because we only care about the online
 	// state when the page first loads
@@ -28,7 +28,7 @@
 				>forum Discord</a
 			>
 			et de nous remonter le problème, ou ouvrez une issue sur
-			<a href="https://github.com/svelte-society-fr/kit">GitHub</a>. Merci !
+			<a href="https://github.com/{PUBLIC_GITHUB_ORG}/kit">GitHub</a>. Merci !
 		</p>
 	{:else}
 		<h1>Il semblerait que vous soyez hors ligne</h1>

--- a/sites/kit.svelte.dev/src/routes/+layout.server.js
+++ b/sites/kit.svelte.dev/src/routes/+layout.server.js
@@ -11,7 +11,7 @@ export const load = async ({ url, fetch }) => {
 
 /** @param {URL} url */
 function get_nav_title(url) {
-	const list = new Map([[/^docs/, 'Docs']]);
+	const list = new Map([[/^docs/, 'Documentation']]);
 
 	for (const [regex, title] of list) {
 		if (regex.test(url.pathname.replace(/^\/(.+)/, '$1'))) {

--- a/sites/kit.svelte.dev/src/routes/+layout.svelte
+++ b/sites/kit.svelte.dev/src/routes/+layout.svelte
@@ -1,7 +1,7 @@
 <script>
 	import { browser } from '$app/environment';
 	import { page } from '$app/stores';
-	import { LEARN_SITE_URL, SVELTE_SITE_URL } from '$env/static/private';
+	import { PUBLIC_LEARN_SITE_URL, PUBLIC_SVELTE_SITE_URL } from '$env/static/public';
 	import { Icon, Shell } from '@sveltejs/site-kit/components';
 	import { Nav, Separator } from '@sveltejs/site-kit/nav';
 	import { Search, SearchBox } from '@sveltejs/site-kit/search';
@@ -34,12 +34,12 @@
 			</svelte:fragment>
 
 			<svelte:fragment slot="external-links">
-				<a href="{LEARN_SITE_URL}/tutorial/introducing-sveltekit" rel="external">Tutoriel</a>
-				<a href={SVELTE_SITE_URL}>Svelte</a>
+				<a href="{PUBLIC_LEARN_SITE_URL}/tutorial/introducing-sveltekit" rel="external">Tutoriel</a>
+				<a href={PUBLIC_SVELTE_SITE_URL}>Svelte</a>
 
 				<Separator />
 
-				<a href="{SVELTE_SITE_URL}/chat" rel="external" title="Discord Chat">
+				<a href="{PUBLIC_SVELTE_SITE_URL}/chat" rel="external" title="Discord Chat">
 					<span class="small">Discord</span>
 					<span class="large"><Icon name="discord" /></span>
 				</a>

--- a/sites/kit.svelte.dev/src/routes/+layout.svelte
+++ b/sites/kit.svelte.dev/src/routes/+layout.svelte
@@ -84,4 +84,14 @@
 	:global(.toggle) {
 		bottom: 0 !important;
 	}
+
+	:global(.text .vo a) {
+		color: var(--sk-text-1);
+		box-shadow: inset 0 -1px 0 0 var(--sk-text-4);
+		transition: color 0.2s ease-in-out;
+	}
+
+	:global(.text .vo a:hover) {
+		color: var(--sk-text-3);
+	}
 </style>

--- a/sites/kit.svelte.dev/src/routes/+layout.svelte
+++ b/sites/kit.svelte.dev/src/routes/+layout.svelte
@@ -1,6 +1,7 @@
 <script>
 	import { browser } from '$app/environment';
 	import { page } from '$app/stores';
+	import { LEARN_SITE_URL, SVELTE_SITE_URL } from '$env/static/private';
 	import { Icon, Shell } from '@sveltejs/site-kit/components';
 	import { Nav, Separator } from '@sveltejs/site-kit/nav';
 	import { Search, SearchBox } from '@sveltejs/site-kit/search';
@@ -17,6 +18,7 @@
 <div style:display={$page.url.pathname !== '/docs' ? 'contents' : 'none'}>
 	<Shell nav_visible={$page.url.pathname !== '/repl/embed'} bind:snapshot={shell_snapshot}>
 		<Nav slot="top-nav" title={data.nav_title} links={data.nav_links}>
+			<svelte:fragment slot="theme-label">Thème</svelte:fragment>
 			<svelte:fragment slot="home-large">
 				<strong>kit</strong>.svelte.dev
 			</svelte:fragment>
@@ -27,18 +29,17 @@
 
 			<svelte:fragment slot="search">
 				{#if $page.url.pathname !== '/search'}
-					<Search />
+					<Search label="Recherche" />
 				{/if}
 			</svelte:fragment>
 
 			<svelte:fragment slot="external-links">
-				<a href="https://learn.svelte.dev/tutorial/introducing-sveltekit" rel="external">Tutorial</a
-				>
-				<a href="https://svelte.dev">Svelte</a>
+				<a href="{LEARN_SITE_URL}/tutorial/introducing-sveltekit" rel="external">Tutoriel</a>
+				<a href={SVELTE_SITE_URL}>Svelte</a>
 
 				<Separator />
 
-				<a href="https://svelte.dev/chat" rel="external" title="Discord Chat">
+				<a href="{SVELTE_SITE_URL}/chat" rel="external" title="Discord Chat">
 					<span class="small">Discord</span>
 					<span class="large"><Icon name="discord" /></span>
 				</a>
@@ -55,7 +56,15 @@
 </div>
 
 {#if browser}
-	<SearchBox />
+	<SearchBox placeholder="Recherche">
+		<svelte:fragment slot="search-description">
+			Les résultats se mettent à jour quand vous écrivez
+		</svelte:fragment>
+		<svelte:fragment slot="idle" let:has_recent_searches>
+			{has_recent_searches ? 'Recherches récentes' : 'Aucune recherche récente'}
+		</svelte:fragment>
+		<svelte:fragment slot="no-results">Aucun résultat</svelte:fragment>
+	</SearchBox>
 {/if}
 
 <style>

--- a/sites/kit.svelte.dev/src/routes/+page.svelte
+++ b/sites/kit.svelte.dev/src/routes/+page.svelte
@@ -69,7 +69,7 @@
 
 	<Footer
 		links={{
-			resources: [
+			ressources: [
 				{
 					title: 'documentation',
 					href: '/docs'
@@ -83,7 +83,7 @@
 					href: `${PUBLIC_SVELTE_SITE_URL}/blog`
 				}
 			],
-			connect: [
+			contact: [
 				{
 					title: 'github',
 					href: 'https://github.com/sveltejs/kit'

--- a/sites/kit.svelte.dev/src/routes/+page.svelte
+++ b/sites/kit.svelte.dev/src/routes/+page.svelte
@@ -10,7 +10,7 @@
 	import schema_url from './schema.json?url';
 
 	import './home/common.css';
-	import { SVELTE_SITE_URL, LEARN_SITE_URL } from '$env/static/private';
+	import { PUBLIC_SVELTE_SITE_URL, PUBLIC_LEARN_SITE_URL } from '$env/static/public';
 
 	let schema;
 	onMount(async () => {
@@ -68,11 +68,11 @@
 				},
 				{
 					title: 'tutoriel',
-					href: `${LEARN_SITE_URL}/tutorial/introducing-sveltekit`
+					href: `${PUBLIC_LEARN_SITE_URL}/tutorial/introducing-sveltekit`
 				},
 				{
 					title: 'blog',
-					href: `${SVELTE_SITE_URL}/blog`
+					href: `${PUBLIC_SVELTE_SITE_URL}/blog`
 				}
 			],
 			connect: [
@@ -86,7 +86,7 @@
 				},
 				{
 					title: 'discord',
-					href: `${SVELTE_SITE_URL}/chat`
+					href: `${PUBLIC_SVELTE_SITE_URL}/chat`
 				},
 				{
 					title: 'twitter',

--- a/sites/kit.svelte.dev/src/routes/+page.svelte
+++ b/sites/kit.svelte.dev/src/routes/+page.svelte
@@ -53,7 +53,15 @@
 
 	<Hero />
 	<Intro />
-	<TrySection />
+	<TrySection>
+		<svelte:fragment slot="content-heading">voyez par vous-même</svelte:fragment>
+		<svelte:fragment slot="content"
+			>Essayez en local, <a target="_blank" rel="noreferrer" href="https://sveltekit.new"
+				>sur StackBlitz</a
+			>, ou bien avec
+			<a target="_blank" href={PUBLIC_LEARN_SITE_URL}>le tutoriel interactif</a>.</svelte:fragment
+		>
+	</TrySection>
 	<Svelte />
 	<Features />
 	<Deployment />

--- a/sites/kit.svelte.dev/src/routes/+page.svelte
+++ b/sites/kit.svelte.dev/src/routes/+page.svelte
@@ -10,6 +10,7 @@
 	import schema_url from './schema.json?url';
 
 	import './home/common.css';
+	import { SVELTE_SITE_URL, LEARN_SITE_URL } from '$env/static/private';
 
 	let schema;
 	onMount(async () => {
@@ -25,13 +26,16 @@
 
 	<meta name="twitter:title" content="SvelteKit" />
 	<meta name="twitter:description" content="Web development, streamlined" />
-	<meta name="description" content="SvelteKit is the official Svelte application framework" />
+	<meta
+		name="description"
+		content="SvelteKit est le framework d'application officiel pour Svelte"
+	/>
 
 	<meta property="og:type" content="website" />
 	<meta property="og:title" content="SvelteKit • Web development, streamlined" />
 	<meta
 		property="og:description"
-		content="SvelteKit is the official Svelte application framework"
+		content="SvelteKit est le framework d'application officiel pour Svelte"
 	/>
 	<meta property="og:url" content="https://kit.svelte.dev/" />
 	<meta
@@ -63,12 +67,12 @@
 					href: '/docs'
 				},
 				{
-					title: 'tutorial',
-					href: 'https://learn.svelte.dev/tutorial/introducing-sveltekit'
+					title: 'tutoriel',
+					href: `${LEARN_SITE_URL}/tutorial/introducing-sveltekit`
 				},
 				{
 					title: 'blog',
-					href: 'https://svelte.dev/blog'
+					href: `${SVELTE_SITE_URL}/blog`
 				}
 			],
 			connect: [
@@ -82,7 +86,7 @@
 				},
 				{
 					title: 'discord',
-					href: 'https://svelte.dev/chat'
+					href: `${SVELTE_SITE_URL}/chat`
 				},
 				{
 					title: 'twitter',
@@ -92,9 +96,9 @@
 		}}
 	>
 		<span slot="license">
-			SvelteKit is <a target="_blank" rel="noreferrer" href="https://github.com/sveltejs/kit"
-				>free and open source software</a
-			> released under the MIT license.
+			SvelteKit est un <a target="_blank" rel="noreferrer" href="https://github.com/sveltejs/kit"
+				>logiciel gratuit et en source ouverte</a
+			> publié sous la licence MIT.
 		</span></Footer
 	>
 </div>

--- a/sites/kit.svelte.dev/src/routes/docs/[slug]/+page.svelte
+++ b/sites/kit.svelte.dev/src/routes/docs/[slug]/+page.svelte
@@ -51,8 +51,11 @@
 <div class="text content" use:copy_code_descendants>
 	<h1>{data.page.title}</h1>
 
-	<a class="edit" href="https://github.com/sveltejs/kit/edit/master/documentation/docs/{data.page.file}">
-		<Icon size={50} name="edit" /> Edit this page on GitHub
+	<a
+		class="edit"
+		href="https://github.com/svelte-society-fr/kit/edit/master/documentation/docs/{data.page.file}"
+	>
+		<Icon size={50} name="edit" /> Éditer cette page sur Github
 	</a>
 
 	<DocsOnThisPage details={data.page} />
@@ -63,14 +66,14 @@
 
 	<div class="controls">
 		<div>
-			<span class:faded={!prev}>previous</span>
+			<span class:faded={!prev}>précédent</span>
 			{#if prev}
 				<a href={prev.path}>{prev.title}</a>
 			{/if}
 		</div>
 
 		<div>
-			<span class:faded={!next}>next</span>
+			<span class:faded={!next}>suivant</span>
 			{#if next}
 				<a href={next.path}>{next.title}</a>
 			{/if}

--- a/sites/kit.svelte.dev/src/routes/docs/[slug]/+page.svelte
+++ b/sites/kit.svelte.dev/src/routes/docs/[slug]/+page.svelte
@@ -1,5 +1,6 @@
 <script>
 	import { page } from '$app/stores';
+	import { PUBLIC_GITHUB_ORG } from '$env/static/public';
 	import { copy_code_descendants } from '@sveltejs/site-kit/actions';
 	import { Icon } from '@sveltejs/site-kit/components';
 	import { DocsOnThisPage, setupDocsHovers } from '@sveltejs/site-kit/docs';
@@ -53,7 +54,8 @@
 
 	<a
 		class="edit"
-		href="https://github.com/svelte-society-fr/kit/edit/master/documentation/docs/{data.page.file}"
+		href="https://github.com/{PUBLIC_GITHUB_ORG}/kit/edit/master/documentation/docs/{data.page
+			.file}"
 	>
 		<Icon size={50} name="edit" /> Éditer cette page sur Github
 	</a>

--- a/sites/kit.svelte.dev/src/routes/home/Deployment.svelte
+++ b/sites/kit.svelte.dev/src/routes/home/Deployment.svelte
@@ -13,8 +13,6 @@
 	import netlify from './logos/netlify.svg';
 	import node from './logos/node.svg';
 	import vercel from './logos/vercel.svg';
-
-	import { KIT_SITE_URL } from '$env/static/private';
 </script>
 
 <Section --background="var(--background-1)">
@@ -110,7 +108,7 @@
 				<img src={azure} alt="" />
 				<span>Azure</span>
 			</a>
-			<a target="_blank" rel="noreferrer" href="{KIT_SITE_URL}/docs/adapters">
+			<a target="_blank" rel="noreferrer" href="/docs/adapters">
 				<img src={plus} alt="" />
 				<span>Et plus...</span>
 			</a>

--- a/sites/kit.svelte.dev/src/routes/home/Deployment.svelte
+++ b/sites/kit.svelte.dev/src/routes/home/Deployment.svelte
@@ -13,19 +13,23 @@
 	import netlify from './logos/netlify.svg';
 	import node from './logos/node.svg';
 	import vercel from './logos/vercel.svg';
+
+	import { KIT_SITE_URL } from '$env/static/private';
 </script>
 
 <Section --background="var(--background-1)">
 	<div class="grid" style="--columns: 3">
-		<h2>deploy anywhere</h2>
+		<h2>déployez partout</h2>
 		<div class="blurb">
 			<p>
-				Export static HTML files. Run your own Node server. Deploy code to the edge of the world. If
-				a platform runs JavaScript, it runs SvelteKit — in some cases with <strong
-					>zero configuration</strong
-				>.
+				Exportez des fichiers HTML statiques. Lancer votre propre serveur Node. Déployez du code aux
+				confins du monde. Si une plateforme fait tourner JavaScript, elle fait tourner SvelteKit —
+				dans certains cas <strong>sans aucune configuration</strong>.
 			</p>
-			<p>Want to try deploying somewhere else? Swap out your adapter with a single line of code.</p>
+			<p>
+				Vous voulez essayer de déployer ailleurs ? Changer votre adaptateur en une seule ligne de
+				code.
+			</p>
 		</div>
 	</div>
 
@@ -38,7 +42,7 @@
 				class="invert"
 			>
 				<img src={html5} alt="" />
-				<span><span class="large">Static</span> HTML</span>
+				<span>HTML <span class="large">statique</span></span>
 			</a>
 			<a
 				target="_blank"
@@ -106,9 +110,9 @@
 				<img src={azure} alt="" />
 				<span>Azure</span>
 			</a>
-			<a target="_blank" rel="noreferrer" href="https://kit.svelte.dev/docs/adapters">
+			<a target="_blank" rel="noreferrer" href="{KIT_SITE_URL}/docs/adapters">
 				<img src={plus} alt="" />
-				<span>More...</span>
+				<span>Et plus...</span>
 			</a>
 		</div>
 
@@ -117,9 +121,9 @@
 				src="{base}/edge.svg?{$theme.current}"
 				width="100%"
 				height="100%"
-				alt="Dynamically rendered map of the world, centered on the user's location"
+				alt="Carte du monde rendue dynamiquement, en fonction de la position de l'utilisateur"
 			/>
-			<span> rendered on the edge, just for you </span>
+			<span> rendu sur le réseau edge, juste pour vous</span>
 		</div>
 	</div>
 </Section>

--- a/sites/kit.svelte.dev/src/routes/home/Features.svelte
+++ b/sites/kit.svelte.dev/src/routes/home/Features.svelte
@@ -11,7 +11,7 @@
 				<strong>rendu dynamique sur le serveur</strong>
 				pour une flexibilité maximale. Transformez votre application en une
 				<strong>PWA</strong> rendue côté client avec une seule ligne de code, pour toute votre
-				application ou une seule page. Utilisez un <strong>routing côté client</strong> accessible
+				application ou seulement une seule page. Utilisez un <strong>routeur côté client</strong> accessible
 				avec du <strong>préchargement</strong> automatique pour une navigation instantanée qui ne
 				recharge pas entièrement votre page (ni vos analytiques, et toutes ces choses qui pèsent
 				lourd). Protégez vos utilisateurs avec de la <strong>protection CSRF</strong>
@@ -24,10 +24,10 @@
 				<strong>typés</strong>
 				et des <strong>actions de formulaire</strong> qui fonctionnent avec ou sans JavaScript.
 				Faites <strong>co-exister</strong> d'autres frameworks utilisant du routing côté client sur
-				la même page. Ajoutez des service workers pour le support <strong>hors ligne</strong>.
+				la même page. Ajoutez des services workers pour le support <strong>hors ligne</strong>.
 				Générez des pages <strong>compatibles AMP</strong> si vous en avez le besoin. Construisez
-				des UIs complexes à l'aide d'un système puissant de routes basé sur votre arborescence de
-				fichiers Des layouts imbriqués ? Évidemment. Apprenez les <strong>standards du web</strong>
+				des UI complexes à l'aide d'un système puissant de routes basé sur votre arborescence de
+				fichiers. Des layouts imbriqués ? Évidemment. Apprenez les <strong>standards du web</strong>
 				qui fonctionnent dans tous les environnements. Utilisez <strong>Tailwind</strong> et
 				<strong>Playwright</strong>
 				et <strong>Vitest</strong> et <strong>Storybook</strong> et, bah, ce que vous voulez.

--- a/sites/kit.svelte.dev/src/routes/home/Features.svelte
+++ b/sites/kit.svelte.dev/src/routes/home/Features.svelte
@@ -5,38 +5,39 @@
 <Section --background="var(--sk-back-1)">
 	<div class="container">
 		<div class="features">
-			<h2><span>features? we got 'em.</span></h2>
+			<h2><span>des fonctionnalités ? on a ça en stock.</span></h2>
 			<p class="wall">
-				Mix and match <strong>prerendered</strong> pages for maximum performance with dynamic
-				<strong>server-side rendering</strong> for maximum flexibility. Turn your app into a
-				client-rendered
-				<strong>PWA</strong> with a single line of code, for the whole thing or just one page. Use
-				accessible <strong>client-side routing</strong> with automatic
-				<strong>preloading</strong> for slick, instantaneous navigation that doesn't reload your
-				entire page (and your analytics, and all that other junk). Protect your users with automatic
-				<strong>CSRF protection</strong>
-				and easy-to-use
-				<strong>Content Security Policy</strong> configuration. Keep your secrets to yourself with
-				advanced <strong>environment variable</strong> handling. Handle errors gracefully and
-				<strong>securely</strong>. Load data
-				<strong>directly from your database</strong>
-				and connect your back end to your front end with <strong>type-safe</strong> data loading and
-				built-in <strong>form actions</strong>
-				that work with or without JavaScript. <strong>Co-exist</strong> with other client-side
-				routing frameworks on the same page. Add service workers for <strong>offline</strong>
-				support. Generate <strong>AMP-compliant</strong>
-				pages if you really have to. Build complex UIs with unusually powerful
-				<strong>filesystem-based routes</strong>. Nested layouts? Duh. Learn
-				<strong>web standards</strong>
-				that work across environments. Integrate with <strong>Tailwind</strong>
-				and <strong>Playwright</strong> and <strong>Vitest</strong> and <strong>Storybook</strong>
-				and, well, whatever you want. Build <strong>libraries</strong> as well as apps.
-				<strong>Deploy anywhere</strong> with adapters.
+				Mélangez des pages <strong>pré-rendues</strong>pour une perfomance optimale avec du
+				<strong>rendu dynamique sur le serveur</strong>
+				pour une flexibilité maximale. Transformez votre application en une
+				<strong>PWA</strong> rendue côté client avec une seule ligne de code, pour toute votre
+				application ou une seule page. Utilisez un <strong>routing côté client</strong> accessible
+				avec du <strong>préchargement</strong> automatique pour une navigation instantanée qui ne
+				recharge pas entièrement votre page (ni vos analytiques, et toutes ces choses qui pèsent
+				lourd). Protégez vos utilisateurs avec de la <strong>protection CSRF</strong>
+				et une configuration
+				<strong>Content Security Policy</strong> simple à utiliser. Gardez vos secrets bien gardés
+				avec une gestion avancée des <strong>variables d'environnement</strong>. Gérez les erreurs
+				proprement et <strong>efficacement</strong>. Chargez la donnée
+				<strong>directement depuis votre base de données</strong>
+				et connectez votre back-end à votre front-end avec des chargements de données
+				<strong>typés</strong>
+				et des <strong>actions de formulaire</strong> qui fonctionnent avec ou sans JavaScript.
+				Faites <strong>co-exister</strong> d'autres frameworks utilisant du routing côté client sur
+				la même page. Ajoutez des service workers pour le support <strong>hors ligne</strong>.
+				Générez des pages <strong>compatibles AMP</strong> si vous en avez le besoin. Construisez
+				des UIs complexes à l'aide d'un système puissant de routes basé sur votre arborescence de
+				fichiers Des layouts imbriqués ? Évidemment. Apprenez les <strong>standards du web</strong>
+				qui fonctionnent dans tous les environnements. Utilisez <strong>Tailwind</strong> et
+				<strong>Playwright</strong>
+				et <strong>Vitest</strong> et <strong>Storybook</strong> et, bah, ce que vous voulez.
+				Développez des <strong>librairies</strong> ou bien des applications.
+				<strong>Déployez partout</strong> avec les adaptateurs.
 			</p>
 
 			<p>
-				SvelteKit is the framework that
-				<strong>grows with you</strong>, whatever you end up building.
+				SvelteKit est le framework qui <strong>grandit avec vous</strong>, peu importe ce que vous
+				construisez.
 			</p>
 		</div>
 	</div>

--- a/sites/kit.svelte.dev/src/routes/home/Features.svelte
+++ b/sites/kit.svelte.dev/src/routes/home/Features.svelte
@@ -7,7 +7,7 @@
 		<div class="features">
 			<h2><span>des fonctionnalités ? on a ça en stock.</span></h2>
 			<p class="wall">
-				Mélangez des pages <strong>pré-rendues</strong>pour une perfomance optimale avec du
+				Mélangez des pages <strong>pré-rendues</strong> pour une perfomance optimale avec du
 				<strong>rendu dynamique sur le serveur</strong>
 				pour une flexibilité maximale. Transformez votre application en une
 				<strong>PWA</strong> rendue côté client avec une seule ligne de code, pour toute votre

--- a/sites/kit.svelte.dev/src/routes/home/Hero.svelte
+++ b/sites/kit.svelte.dev/src/routes/home/Hero.svelte
@@ -13,7 +13,7 @@
 			</div>
 
 			<div class="tagline">web development, streamlined</div>
-			<a href="{base}/docs/introduction" class="cta"> read the docs </a>
+			<a href="{base}/docs/introduction" class="cta"> lire la documentation </a>
 		</div>
 
 		<div class="hero-image">

--- a/sites/kit.svelte.dev/src/routes/home/Intro.svelte
+++ b/sites/kit.svelte.dev/src/routes/home/Intro.svelte
@@ -1,31 +1,32 @@
 <script>
+	import { PUBLIC_SVELTE_SITE_URL } from '$env/static/public';
 	import { Blurb } from '@sveltejs/site-kit/home';
 </script>
 
 <Blurb --background="var(--sk-back-1)">
 	<div slot="one">
-		<h2>fast</h2>
+		<h2>rapide</h2>
 		<p>
-			Powered by <a target="_blank" rel="noreferrer" href="https://svelte.dev">Svelte</a> and
-			<a target="_blank" rel="noreferrer" href="https://vitejs.dev">Vite</a>, speed is baked into
-			every crevice: fast setup, fast dev, fast builds, fast page loads, fast navigation. Did we
-			mention it's fast?
+			Basé sur <a target="_blank" rel="noreferrer" href={PUBLIC_SVELTE_SITE_URL}>Svelte</a> et
+			<a target="_blank" rel="noreferrer" href="https://vitejs.dev">Vite</a>, la vitesse est gravée
+			dans chaque recoin : installation rapide, développement rapide, builds rapides, chargements de
+			page rapides, navigation rapide. On a mentionné que c'était rapide ?
 		</p>
 	</div>
 
 	<div slot="two">
 		<h2>fun</h2>
 		<p>
-			No more wasted days figuring out bundler configuration, routing, SSR, CSP, TypeScript,
-			deployment settings and all the other boring stuff. Code with joy.
+			Plus de journées perdues dans des galères de configuration de compilateur, de routing, SSR,
+			CSP, TypeScript, paramètres de déploiement et tout autre sujet pénible. Codez avec le sourire.
 		</p>
 	</div>
 
 	<div slot="three">
 		<h2>flexible</h2>
 		<p>
-			SPA? MPA? SSR? SSG? Check. SvelteKit gives you the tools to succeed whatever it is you're
-			building. And it runs wherever JavaScript does.
+			SPA ? MPA ? SSR ? SSG ? Check. SvelteKit vous fournit les outils pour réussir quelque soit ce
+			que vous construisez. Et ça fonctionne partout où JavaScript fonctionne.
 		</p>
 	</div>
 </Blurb>

--- a/sites/kit.svelte.dev/src/routes/home/Showcase.svelte
+++ b/sites/kit.svelte.dev/src/routes/home/Showcase.svelte
@@ -23,7 +23,7 @@
 </script>
 
 <Section --background="var(--background-2)">
-	<h2>showcase</h2>
+	<h2>galerie</h2>
 
 	<div class="showcase">
 		{#each showcase as { url, image }}

--- a/sites/kit.svelte.dev/src/routes/home/Svelte.svelte
+++ b/sites/kit.svelte.dev/src/routes/home/Svelte.svelte
@@ -5,8 +5,10 @@
 
 <Section --background="var(--background-1)">
 	<p class="definition">
-		<em>/ˈsvɛlt/</em> <span class="adjective">adjective</span>
-		<span class="description">attractively thin, graceful and stylish</span>
+		<em>/ˈsvɛlt/</em> <span class="adjective">adjectif</span>
+		<span class="description"
+			>qui produit une impression de légèreté, de souplesse, par sa forme élancée.</span
+		>
 	</p>
 
 	<div class="grid" style="--columns: 3">
@@ -19,42 +21,43 @@
 					rel="noreferrer"
 					href="https://www.offerzen.com/community/svelte-origins-documentary"
 				>
-					Watch the full Svelte Origins documentary
+					Regarder le documentaire Svelte Origins en entier
 				</a>
 			</p>
 		</div>
 
 		<div>
 			<p>
-				SvelteKit is built on Svelte, a UI framework that uses a compiler to let you write
-				breathtakingly concise components that do minimal work in the browser, using languages you
-				already know — HTML, CSS and JavaScript. <strong
-					>It's a love letter to web development.</strong
-				>
+				SvelteKit est construit par dessus Svelte, un framework d'interface qui utilise un
+				compilateur pour vous permettre d'écrire des composants incroyablement concis qui effectuent
+				le minimum de travail dans le navigateur, en utilisant des langages que vous connaissez
+				déjà, HTML, CSS, JavaScript. <strong>C'est une lettre d'amour au développment web.</strong>
 			</p>
 
 			<p>
-				But don't take our word for it. Developers consistently rank Svelte as the framework they're
+				Mais ne nous prenez pas au mot. Les développeurs et développeuses notent régulièrement
+				Svelte comme le framework qu'
 				<a
 					target="_blank"
 					rel="noreferrer"
 					href="https://insights.stackoverflow.com/survey/2021#section-most-loved-dreaded-and-wanted-web-frameworks"
 				>
-					most
+					ils
 				</a>
+				ou
 				<a
 					target="_blank"
 					rel="noreferrer"
 					href="https://tsh.io/state-of-frontend/#which-of-the-following-frameworks-would-you-like-to-learn-in-the-future"
 				>
-					excited
+					elles
 				</a>
 				<a
 					target="_blank"
 					rel="noreferrer"
 					href="https://2021.stateofjs.com/en-US/libraries/front-end-frameworks/"
 				>
-					about
+					préfèrent
 				</a>
 
 				<a
@@ -62,7 +65,7 @@
 					rel="noreferrer"
 					href="https://twitter.com/Rich_Harris/status/1589675637195042817"
 				>
-					using</a
+					utiliser</a
 				>.
 			</p>
 		</div>

--- a/sites/kit.svelte.dev/src/routes/home/subtitles.vtt
+++ b/sites/kit.svelte.dev/src/routes/home/subtitles.vtt
@@ -22,7 +22,7 @@ WEBVTT
  de construire un site web qui rend ça plus fun
 
 00:00:13.160 --> 00:00:15.440
- et facile que tout ce que l'on connu depuis longtemps.
+ et plus facile que tout ce que l'on a connu depuis longtemps.
 
 00:00:15.440 --> 00:00:18.720
  Et cela est fait en introduisant
@@ -40,7 +40,7 @@ WEBVTT
  [Amelia Wattenberger] Vous manipulez principalement du HTML,
 
 00:00:32.760 --> 00:00:34.760
- JavaScript, et CSS basiques.
+ du JavaScript, et du CSS basiques.
 
 00:00:34.760 --> 00:00:37.120
  [Aliza Aufrichtig] La chose que je préfère quand j'utilise Svelte
@@ -79,7 +79,7 @@ WEBVTT
  ou une des plus hautes parmi les principaux frameworks
 
 00:01:05.920 --> 00:01:08.120
- JavaScript les plus utilisés.
+ JavaScript utilisés.
 
 00:01:08.120 --> 00:01:10.040
  [Guillermo Rauch] Lorsque vous écrivez votre application,
@@ -91,7 +91,7 @@ WEBVTT
  C'est presque impossible de créer une application lente
 
 00:01:14.880 --> 00:01:17.200
- et je pense qu'en ça Svelte a un avantage incroyable.
+ et je pense qu'en ça, Svelte a un avantage incroyable.
 
 00:01:17.200 --> 00:01:18.360
  Les gens adorent Svelte.

--- a/sites/kit.svelte.dev/src/routes/home/subtitles.vtt
+++ b/sites/kit.svelte.dev/src/routes/home/subtitles.vtt
@@ -1,98 +1,98 @@
 WEBVTT
 
 00:00:00.000 --> 00:00:01.920
- [Scott Tolinski] I wanted to share it immediately.
+ [Scott Tolinski] J'avais envie de le partager immédiatement.
 
 00:00:01.920 --> 00:00:04.240
- I wanted to build more things in it.
+ Je voulais construire plus de choses avec.
 
 00:00:04.240 --> 00:00:05.640
- [James Q Quick] I love it.
+ [James Q Quick] J'adore.
 
 00:00:05.640 --> 00:00:07.080
- [Fireship] It's the only JavaScript framework
+ [Fireship] C'est le seul framework JavaScript
 
 00:00:07.080 --> 00:00:08.640
- that's actually enjoyable to use.
+ qui est vraiment agréable à utiliser.
 
 00:00:08.640 --> 00:00:10.540
- [Ben McCann] Svelte introduced a new ergonomics
+ [Ben McCann] Svelte apporte une nouvelle façon
 
 00:00:10.540 --> 00:00:13.160
- to building a website that's made it more fun
+ de construire un site web qui rend ça plus fun
 
 00:00:13.160 --> 00:00:15.440
- and easier than it's been in a long time.
+ et facile que tout ce que l'on connu depuis longtemps.
 
 00:00:15.440 --> 00:00:18.720
- And the way that it's done that is by introducing
+ Et cela est fait en introduisant
 
 00:00:18.720 --> 00:00:22.360
- this concept of generating reactive code at compile time.
+ ce concept de générer du code réactif à la compilation.
 
 00:00:22.360 --> 00:00:25.560
- [Scott Tolinski] What Svelte allows us to do is to write code
+ [Scott Tolinski] Ce que Svelte nous permet est d'écrire du code
 
 00:00:25.560 --> 00:00:29.400
- that's not only small and simple, but plain and readable.
+ qui n'est pas juste court et simple, mais transparent et lisible.
 
 00:00:29.400 --> 00:00:32.760
- [Amelia Wattenberger] You're mostly just looking at basic HTML,
+ [Amelia Wattenberger] Vous manipulez principalement du HTML,
 
 00:00:32.760 --> 00:00:34.760
- JavaScript, and CSS.
+ JavaScript, et CSS basiques.
 
 00:00:34.760 --> 00:00:37.120
- [Aliza Aufrichtig] The thing I like most about using Svelte
+ [Aliza Aufrichtig] La chose que je préfère quand j'utilise Svelte
 
 00:00:37.120 --> 00:00:39.200
- is how fast you can move.
+ c'est à quel point vous allez vite.
 
 00:00:39.200 --> 00:00:42.400
- [Moritz Stefaner] And when I discovered Svelte, it came back to this,
+ [Moritz Stefaner] Et quand j'ai découvert Svelte, cela revenait à ça,
 
 00:00:42.400 --> 00:00:44.800
- oh, here's a really simple way to do things.
+ oh, ça c'est une façon vraiment simple de faire les choses.
 
 00:00:44.800 --> 00:00:47.480
- [Shawn Wang] You don't actually need all this machinery
+ [Shawn Wang] Vous n'avez pas vraiment besoin de toute cette machinerie
 
 00:00:47.480 --> 00:00:49.120
- in order to do components right.
+ pour faire des composants correctement.
 
 00:00:49.120 --> 00:00:51.640
- I looked at my React experience so far —
+ J'ai repensé à mon expérience avec React —
 
 00:00:51.640 --> 00:00:55.120
- I could not be anywhere as productive as I could be in Svelte.
+ J'étais loin d'être aussi productif que je ne l'étais avec Svelte.
 
 00:00:55.120 --> 00:00:57.520
- And that's when it started really taking it seriously.
+ Et c'est là qu'on a commencé à le prendre vraiment au sérieux.
 
 00:00:57.520 --> 00:00:59.800
- [Amelia Wattenberger] There's quite a bit of usage these days
+ [Amelia Wattenberger] Ça commence à être pas mal utilisé
 
 00:00:59.800 --> 00:01:02.680
- and satisfaction is still, I think, the highest
+ et la satisfaction est toujours, je crois, la plus haute
 
 00:01:02.680 --> 00:01:05.920
- or one of the highest for any of the larger
+ ou une des plus hautes parmi les principaux frameworks
 
 00:01:05.920 --> 00:01:08.120
- or more used JavaScript frameworks.
+ JavaScript les plus utilisés.
 
 00:01:08.120 --> 00:01:10.040
- [Guillermo Rauch] When you write your application,
+ [Guillermo Rauch] Lorsque vous écrivez votre application,
 
 00:01:10.040 --> 00:01:13.160
- you're making it fast by construction.
+ vous la rendez rapide par sa construction.
 
 00:01:13.160 --> 00:01:14.880
- It's almost impossible to create a slow app
+ C'est presque impossible de créer une application lente
 
 00:01:14.880 --> 00:01:17.200
- and I think Svelte has an incredible advantage here.
+ et je pense qu'en ça Svelte a un avantage incroyable.
 
 00:01:17.200 --> 00:01:18.360
- People love Svelte.
+ Les gens adorent Svelte.
 

--- a/sites/kit.svelte.dev/src/routes/nav.json/+server.js
+++ b/sites/kit.svelte.dev/src/routes/nav.json/+server.js
@@ -19,7 +19,7 @@ async function get_nav_list() {
 
 	return [
 		{
-			title: 'Docs',
+			title: 'Documentation',
 			prefix: 'docs',
 			pathname: '/docs/introduction',
 			sections: [

--- a/sites/kit.svelte.dev/src/routes/schema.json
+++ b/sites/kit.svelte.dev/src/routes/schema.json
@@ -2,19 +2,13 @@
 	"@context": "http://schema.org",
 	"@type": "SoftwareSourceCode",
 	"name": "SvelteKit",
-	"description": "SvelteKit is the official Svelte application framework.",
+	"description": "SvelteKit est le framework d'application officiel pour Svelte.",
 	"url": "https://kit.svelte.dev/",
 	"codeRepository": "https://github.com/sveltejs/kit",
 	"dateCreated": "2020-10-15T16:00:00",
-	"programmingLanguage": [
-		"JavaScript",
-		"TypeScript"
-	],
+	"programmingLanguage": ["JavaScript", "TypeScript"],
 	"image": "https://raw.githubusercontent.com/sveltejs/branding/master/svelte-logo.svg",
-	"sameAs": [
-		"https://github.com/sveltejs/kit",
-		"https://www.npmjs.com/package/@sveltejs/kit"
-	],
+	"sameAs": ["https://github.com/sveltejs/kit", "https://www.npmjs.com/package/@sveltejs/kit"],
 	"license": "https://github.com/sveltejs/kit/blob/master/LICENSE",
 	"releasedEvent": {
 		"@type": "PublicationEvent",
@@ -24,75 +18,72 @@
 			"https://www.youtube.com/watch?v=N4BRVkQVoMc"
 		]
 	},
-	"contributor": [{
-		"@type": "Person",
-		"name": "Rich Harris",
-		"url": "https://www.rich-harris.co.uk",
-		"image": "https://avatars.githubusercontent.com/u/1162160",
-		"sameAs": [
-			"https://github.com/Rich-Harris",
-			"https://twitter.com/Rich_Harris"
-		]	
-	}, {
-		"@type": "Person",
-		"name": "Ben McCann",
-		"url": "https://www.benmccann.com",
-		"image": "https://avatars.githubusercontent.com/u/322311",
-		"sameAs": [
-			"https://github.com/benmccann",
-			"https://twitter.com/benjaminmccann",
-			"https://about.me/benmccann",
-			"https://angel.co/ben-mccann",
-			"https://www.crunchbase.com/person/benjamin-mccann",
-			"https://www.linkedin.com/in/benmccann"
-		]	
-	}, {
-		"@type": "Person",
-		"name": "Simon Holthausen",
-		"image": "https://avatars.githubusercontent.com/u/5968653",
-		"sameAs": [
-			"https://github.com/dummdidumm",
-			"https://twitter.com/dummdidumm_"
-		]	
-	}, {
-		"@type": "Person",
-		"name": "Ignatius Bagus",
-		"url": "https://mauss.dev/",
-		"image": "https://avatars.githubusercontent.com/u/8156777",
-		"sameAs": [
-			"https://twitter.com/alchemauss",
-			"https://github.com/ignatiusmb",
-			"https://gitlab.com/ignatiusmb",
-			"https://www.linkedin.com/in/ignatiusmb"
-		]	
-	}, {
-		"@type": "Person",
-		"name": "Conduitry",
-		"url": "https://conduitry.dev/",
-		"image": "https://avatars.githubusercontent.com/u/16696352",
-		"sameAs": [
-			"https://github.com/Conduitry"
-		]	
-	}, {
-		"@type": "Person",
-		"name": "Dominik Göpel",
-		"url": "https://goepel.it/",
-		"image": "https://avatars.githubusercontent.com/u/611613",
-		"sameAs": [
-			"https://github.com/dominikg",
-			"https://m.webtoo.ls/@dominikg"
-		]	
-	}, {
-		"@type": "Person",
-		"name": "Bjorn Lu",
-		"url": "https://bjornlu.com/",
-		"image": "https://avatars.githubusercontent.com/u/34116392",
-		"sameAs": [
-			"https://github.com/bluwy",
-			"https://twitter.com/bluwyoo",
-			"https://m.webtoo.ls/@bluwy",
-			"https://www.linkedin.com/in/bjorn-lu-3302a31b5",
-			"https://www.reddit.com/user/IamLUG"
-		]	
-	}]
+	"contributor": [
+		{
+			"@type": "Person",
+			"name": "Rich Harris",
+			"url": "https://www.rich-harris.co.uk",
+			"image": "https://avatars.githubusercontent.com/u/1162160",
+			"sameAs": ["https://github.com/Rich-Harris", "https://twitter.com/Rich_Harris"]
+		},
+		{
+			"@type": "Person",
+			"name": "Ben McCann",
+			"url": "https://www.benmccann.com",
+			"image": "https://avatars.githubusercontent.com/u/322311",
+			"sameAs": [
+				"https://github.com/benmccann",
+				"https://twitter.com/benjaminmccann",
+				"https://about.me/benmccann",
+				"https://angel.co/ben-mccann",
+				"https://www.crunchbase.com/person/benjamin-mccann",
+				"https://www.linkedin.com/in/benmccann"
+			]
+		},
+		{
+			"@type": "Person",
+			"name": "Simon Holthausen",
+			"image": "https://avatars.githubusercontent.com/u/5968653",
+			"sameAs": ["https://github.com/dummdidumm", "https://twitter.com/dummdidumm_"]
+		},
+		{
+			"@type": "Person",
+			"name": "Ignatius Bagus",
+			"url": "https://mauss.dev/",
+			"image": "https://avatars.githubusercontent.com/u/8156777",
+			"sameAs": [
+				"https://twitter.com/alchemauss",
+				"https://github.com/ignatiusmb",
+				"https://gitlab.com/ignatiusmb",
+				"https://www.linkedin.com/in/ignatiusmb"
+			]
+		},
+		{
+			"@type": "Person",
+			"name": "Conduitry",
+			"url": "https://conduitry.dev/",
+			"image": "https://avatars.githubusercontent.com/u/16696352",
+			"sameAs": ["https://github.com/Conduitry"]
+		},
+		{
+			"@type": "Person",
+			"name": "Dominik Göpel",
+			"url": "https://goepel.it/",
+			"image": "https://avatars.githubusercontent.com/u/611613",
+			"sameAs": ["https://github.com/dominikg", "https://m.webtoo.ls/@dominikg"]
+		},
+		{
+			"@type": "Person",
+			"name": "Bjorn Lu",
+			"url": "https://bjornlu.com/",
+			"image": "https://avatars.githubusercontent.com/u/34116392",
+			"sameAs": [
+				"https://github.com/bluwy",
+				"https://twitter.com/bluwyoo",
+				"https://m.webtoo.ls/@bluwy",
+				"https://www.linkedin.com/in/bjorn-lu-3302a31b5",
+				"https://www.reddit.com/user/IamLUG"
+			]
+		}
+	]
 }

--- a/sites/kit.svelte.dev/src/routes/search/+page.svelte
+++ b/sites/kit.svelte.dev/src/routes/search/+page.svelte
@@ -5,16 +5,18 @@
 </script>
 
 <svelte:head>
-	<title>Search • SvelteKit</title>
+	<title>Rechercher • SvelteKit</title>
 </svelte:head>
 
 <main>
-	<h1>Search</h1>
+	<h1>Rechercher</h1>
 	<form>
-		<input name="q" value={data.query} placeholder="Search" spellcheck="false" />
+		<input name="q" value={data.query} placeholder="Rechercher" spellcheck="false" />
 	</form>
 
-	<SearchResults results={data.results} query={data.query} />
+	<SearchResults results={data.results} query={data.query}>
+		<svelte:fragment slot="no-results">Aucun résultat</svelte:fragment>
+	</SearchResults>
 </main>
 
 <style>


### PR DESCRIPTION
Je me rends compte maintenant (je le savais, mais j'avais oublié), qu'il y a un glossaire dans la doc de SvelteKit, qui inclut notamment les items SSR, CSR, etc...

On fait quoi ?
- on laisse ces entrées dans le glossaire de la doc de Svelte aussi
- on sépare, ce qui fait 2 glossaires à 2 endroits différents

J'avoue, je n'ai pas de réponse parfaitement satisfaisante...